### PR TITLE
New IdP wizards

### DIFF
--- a/apps/wizard-v2/src/data/providers.ts
+++ b/apps/wizard-v2/src/data/providers.ts
@@ -119,6 +119,66 @@ export const providers: Provider[] = [
     logo: "/wizards/salesforce/salesforce-logo.png",
     protocols: ["saml", "oidc"],
   },
+  {
+    id: "cas",
+    name: "CAS",
+    logo: "/provider-logos/saml_logo.svg",
+    protocols: ["saml"],
+  },
+  {
+    id: "classlink",
+    name: "ClassLink",
+    logo: "/provider-logos/saml_logo.svg",
+    protocols: ["saml"],
+  },
+  {
+    id: "keycloak",
+    name: "Keycloak",
+    logo: "/provider-logos/saml_logo.svg",
+    protocols: ["saml"],
+  },
+  {
+    id: "miniorange",
+    name: "miniOrange",
+    logo: "/provider-logos/saml_logo.svg",
+    protocols: ["saml"],
+  },
+  {
+    id: "netiq",
+    name: "NetIQ",
+    logo: "/provider-logos/saml_logo.svg",
+    protocols: ["saml"],
+  },
+  {
+    id: "pingfederate",
+    name: "PingFederate",
+    logo: "/provider-logos/ping_federate_logo.png",
+    protocols: ["saml"],
+  },
+  {
+    id: "rippling",
+    name: "Rippling",
+    logo: "/provider-logos/saml_logo.svg",
+    protocols: ["saml"],
+  },
+  {
+    id: "shibboleth",
+    name: "Shibboleth",
+    logo: "/provider-logos/saml_logo.svg",
+    protocols: ["saml"],
+  },
+  {
+    id: "simplesamlphp",
+    name: "SimpleSAMLphp",
+    logo: "/provider-logos/saml_logo.svg",
+    protocols: ["saml"],
+  },
+  {
+    id: "vmware",
+    name: "VMware Workspace ONE",
+    logo: "/provider-logos/vmware_logo.svg",
+    protocols: ["saml"],
+  },
 ];
 
 export const allProviders = [...genericProviders, ...providers];

--- a/apps/wizard-v2/src/data/providers.ts
+++ b/apps/wizard-v2/src/data/providers.ts
@@ -69,7 +69,7 @@ export const providers: Provider[] = [
     id: "google",
     name: "Google Workspace",
     logo: "/provider-logos/google-workspace-logo.svg",
-    protocols: ["saml"],
+    protocols: ["saml", "oidc"],
   },
   {
     id: "jumpcloud",
@@ -87,13 +87,13 @@ export const providers: Provider[] = [
     id: "entraid",
     name: "Microsoft Entra ID",
     logo: "/provider-logos/msft_entraid.svg",
-    protocols: ["saml"],
+    protocols: ["saml", "oidc"],
   },
   {
     id: "okta",
     name: "Okta",
     logo: "/provider-logos/okta_logo.png",
-    protocols: ["saml", "ldap"],
+    protocols: ["saml", "oidc", "ldap"],
   },
   {
     id: "onelogin",
@@ -120,16 +120,34 @@ export const providers: Provider[] = [
     protocols: ["saml", "oidc"],
   },
   {
+    id: "adp",
+    name: "ADP",
+    logo: "/provider-logos/openid_logo.png",
+    protocols: ["oidc"],
+  },
+  {
     id: "cas",
     name: "CAS",
     logo: "/provider-logos/saml_logo.svg",
     protocols: ["saml"],
   },
   {
+    id: "clever",
+    name: "Clever",
+    logo: "/provider-logos/openid_logo.png",
+    protocols: ["oidc"],
+  },
+  {
     id: "classlink",
     name: "ClassLink",
     logo: "/provider-logos/saml_logo.svg",
     protocols: ["saml"],
+  },
+  {
+    id: "logingov",
+    name: "Login.gov",
+    logo: "/provider-logos/openid_logo.png",
+    protocols: ["oidc"],
   },
   {
     id: "keycloak",

--- a/apps/wizard-v2/wizards/adp/oidc.json
+++ b/apps/wizard-v2/wizards/adp/oidc.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": "1.0",
+  "id": "adp-oidc",
+  "providerId": "adp",
+  "protocol": "oidc",
+  "title": "ADP OpenID Connect",
+  "alias": {
+    "prefix": "adp-oidc",
+    "sessionKey": "p2_adp_oidc"
+  },
+  "idpConfig": {
+    "providerId": "oidc",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "clientAuthMethod": "client_secret_post"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Register an API Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the ADP Developer Portal, register a new application and request OpenID Connect credentials. Note the Client ID and Client Secret."
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Redirect URI",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In your ADP application settings, add the following URL as a redirect URI."
+        },
+        {
+          "type": "copy",
+          "label": "Redirect URI",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Add this as a redirect URI in the ADP Developer Portal"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Client Credentials",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Enter the Client ID and Client Secret from your ADP application."
+        },
+        {
+          "type": "formGroup",
+          "id": "adpCreds",
+          "exclusive": false,
+          "forms": [
+            "clientCredentials"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create ADP Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create OIDC Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkOidc}}",
+          "adminButtonText": "Manage OIDC Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "clientCredentials": {
+      "title": "ADP Credentials",
+      "description": "Enter the client credentials from the ADP Developer Portal.",
+      "fields": [
+        {
+          "id": "clientId",
+          "type": "text",
+          "label": "Client ID",
+          "placeholder": "your-client-id",
+          "required": true
+        },
+        {
+          "id": "clientSecret",
+          "type": "password",
+          "label": "Client Secret",
+          "placeholder": "your-client-secret",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Verify & Save",
+        "action": "validateCredentials"
+      }
+    }
+  },
+  "actions": {
+    "validateCredentials": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "https://accounts.adp.com/.well-known/openid-configuration",
+        "providerId": "oidc"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED",
+          "CREDENTIALS_PROVIDED"
+        ]
+      },
+      "messages": {
+        "success": "ADP OIDC configuration verified. You can now create the identity provider.",
+        "error": "Could not fetch ADP OIDC configuration. Please try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "oidc",
+        "hideOnLogin": true,
+        "config": {
+          "syncMode": "FORCE",
+          "clientAuthMethod": "client_secret_post",
+          "clientId": "{{state.formValues.clientId}}",
+          "clientSecret": "{{state.formValues.clientSecret}}",
+          "$spread": "{{state.metadata}}"
+        }
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "ADP Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/cas/saml.json
+++ b/apps/wizard-v2/wizards/cas/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "cas-saml",
+  "providerId": "cas",
+  "protocol": "saml",
+  "title": "CAS SAML",
+  "alias": {
+    "prefix": "cas-saml",
+    "sessionKey": "p2_cas_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Register a SAML Service Provider",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In your CAS server, register a new SAML service provider. Add the following values to the service definition."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Sometimes called SSO Service URL or Callback URL"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Sometimes called Audience URI or SP Entity ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "Sometimes called Entity Provider Metadata or Descriptor URL"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Application Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Copy the CAS SAML2 IdP metadata URL. This is typically available at /cas/idp/metadata."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataUrl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Configure CAS to release the following SAML attributes to this service provider."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "uid",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "mail",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "givenName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "sn",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataUrl": {
+      "title": "Metadata URL",
+      "description": "Paste the SAML metadata URL provided by your identity provider.",
+      "fields": [
+        {
+          "id": "url",
+          "type": "url",
+          "label": "Metadata URL",
+          "placeholder": "https://cas.example.com/cas/idp/metadata",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate URL",
+        "action": "validateMetadataUrl"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataUrl": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "{{form.url}}",
+        "providerId": "saml"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata URL validated. Continue to the next step.",
+        "error": "Validation failed. Check the URL and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "uid",
+          "friendlyName": "uid",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "mail",
+          "friendlyName": "mail",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "givenName",
+          "friendlyName": "givenName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "sn",
+          "friendlyName": "sn",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/classlink/saml.json
+++ b/apps/wizard-v2/wizards/classlink/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "classlink-saml",
+  "providerId": "classlink",
+  "protocol": "saml",
+  "title": "ClassLink SAML",
+  "alias": {
+    "prefix": "classlink-saml",
+    "sessionKey": "p2_classlink_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create a SAML Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the ClassLink Management Console, add a new SAML application. Enter the following service provider details in the application configuration."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Sometimes called SSO Service URL or Callback URL"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Sometimes called Audience URI or SP Entity ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "Sometimes called Entity Provider Metadata or Descriptor URL"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Application Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Copy the IdP metadata URL from ClassLink. This is available in the application's SSO settings."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataUrl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Configure your identity provider to send the following SAML attributes."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "username",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "email",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "firstName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "lastName",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataUrl": {
+      "title": "Metadata URL",
+      "description": "Paste the SAML metadata URL provided by your identity provider.",
+      "fields": [
+        {
+          "id": "url",
+          "type": "url",
+          "label": "Metadata URL",
+          "placeholder": "https://launchpad.classlink.com/saml/metadata",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate URL",
+        "action": "validateMetadataUrl"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataUrl": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "{{form.url}}",
+        "providerId": "saml"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata URL validated. Continue to the next step.",
+        "error": "Validation failed. Check the URL and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "username",
+          "friendlyName": "username",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "email",
+          "friendlyName": "email",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "firstName",
+          "friendlyName": "firstName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "lastName",
+          "friendlyName": "lastName",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/clever/oidc.json
+++ b/apps/wizard-v2/wizards/clever/oidc.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": "1.0",
+  "id": "clever-oidc",
+  "providerId": "clever",
+  "protocol": "oidc",
+  "title": "Clever OpenID Connect",
+  "alias": {
+    "prefix": "clever-oidc",
+    "sessionKey": "p2_clever_oidc"
+  },
+  "idpConfig": {
+    "providerId": "oidc",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "clientAuthMethod": "client_secret_post"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create a Clever Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the Clever Developer Dashboard, create a new application. Note the Client ID and Client Secret from the application settings."
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Redirect URI",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In your Clever application settings, add the following URL as a redirect URI."
+        },
+        {
+          "type": "copy",
+          "label": "Redirect URI",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Add this as a redirect URI in the Clever Developer Dashboard"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Client Credentials",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Enter the Client ID and Client Secret from your Clever application."
+        },
+        {
+          "type": "formGroup",
+          "id": "cleverCreds",
+          "exclusive": false,
+          "forms": [
+            "clientCredentials"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create Clever Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create OIDC Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkOidc}}",
+          "adminButtonText": "Manage OIDC Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "clientCredentials": {
+      "title": "Clever Credentials",
+      "description": "Enter the client credentials from the Clever Developer Dashboard.",
+      "fields": [
+        {
+          "id": "clientId",
+          "type": "text",
+          "label": "Client ID",
+          "placeholder": "your-client-id",
+          "required": true
+        },
+        {
+          "id": "clientSecret",
+          "type": "password",
+          "label": "Client Secret",
+          "placeholder": "your-client-secret",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Verify & Save",
+        "action": "validateCredentials"
+      }
+    }
+  },
+  "actions": {
+    "validateCredentials": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "https://clever.com/.well-known/openid-configuration",
+        "providerId": "oidc"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED",
+          "CREDENTIALS_PROVIDED"
+        ]
+      },
+      "messages": {
+        "success": "Clever OIDC configuration verified. You can now create the identity provider.",
+        "error": "Could not fetch Clever OIDC configuration. Please try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "oidc",
+        "hideOnLogin": true,
+        "config": {
+          "syncMode": "FORCE",
+          "clientAuthMethod": "client_secret_post",
+          "clientId": "{{state.formValues.clientId}}",
+          "clientSecret": "{{state.formValues.clientSecret}}",
+          "$spread": "{{state.metadata}}"
+        }
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "Clever Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/entraid/oidc.json
+++ b/apps/wizard-v2/wizards/entraid/oidc.json
@@ -1,0 +1,172 @@
+{
+  "schemaVersion": "1.0",
+  "id": "entraid-oidc",
+  "providerId": "entraid",
+  "protocol": "oidc",
+  "title": "Microsoft Entra ID OpenID Connect",
+  "alias": {
+    "prefix": "entraid-oidc",
+    "sessionKey": "p2_entraid_oidc"
+  },
+  "idpConfig": {
+    "providerId": "oidc",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "clientAuthMethod": "client_secret_post"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Register an Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the Microsoft Entra admin center, go to App registrations and create a new registration. Note the Application (client) ID and Directory (tenant) ID from the Overview page. Then go to Certificates & secrets and create a new client secret."
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Tenant & Credentials",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Enter your Microsoft Entra tenant ID and the client credentials from your app registration. The tenant ID is used to fetch the OpenID Connect configuration automatically."
+        },
+        {
+          "type": "formGroup",
+          "id": "entraCreds",
+          "exclusive": false,
+          "forms": [
+            "tenantCredentials"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Redirect URI",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In your Entra app registration under Authentication, add the following URL as a Web redirect URI."
+        },
+        {
+          "type": "copy",
+          "label": "Redirect URI",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Add this as a Web redirect URI in the Authentication section"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create Entra ID Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create OIDC Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkOidc}}",
+          "adminButtonText": "Manage OIDC Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "tenantCredentials": {
+      "title": "Entra ID Credentials",
+      "description": "Enter your Microsoft Entra tenant ID and client credentials.",
+      "fields": [
+        {
+          "id": "tenantId",
+          "type": "text",
+          "label": "Tenant ID",
+          "placeholder": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+          "required": true
+        },
+        {
+          "id": "clientId",
+          "type": "text",
+          "label": "Application (Client) ID",
+          "placeholder": "your-application-id",
+          "required": true
+        },
+        {
+          "id": "clientSecret",
+          "type": "password",
+          "label": "Client Secret Value",
+          "placeholder": "your-client-secret-value",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Verify & Save",
+        "action": "validateTenantCredentials"
+      }
+    }
+  },
+  "actions": {
+    "validateTenantCredentials": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "https://login.microsoftonline.com/{{form.tenantId}}/v2.0/.well-known/openid-configuration",
+        "providerId": "oidc"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED",
+          "CREDENTIALS_PROVIDED"
+        ]
+      },
+      "messages": {
+        "success": "Entra ID configuration verified. Continue to set the redirect URI.",
+        "error": "Could not fetch configuration. Check the tenant ID and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "oidc",
+        "hideOnLogin": true,
+        "config": {
+          "syncMode": "FORCE",
+          "clientAuthMethod": "client_secret_post",
+          "clientId": "{{state.formValues.clientId}}",
+          "clientSecret": "{{state.formValues.clientSecret}}",
+          "$spread": "{{state.metadata}}"
+        }
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "Entra ID Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/google/oidc.json
+++ b/apps/wizard-v2/wizards/google/oidc.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": "1.0",
+  "id": "google-oidc",
+  "providerId": "google",
+  "protocol": "oidc",
+  "title": "Google OpenID Connect",
+  "alias": {
+    "prefix": "google-oidc",
+    "sessionKey": "p2_google_oidc"
+  },
+  "idpConfig": {
+    "providerId": "oidc",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "clientAuthMethod": "client_secret_post"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create OAuth Credentials",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the Google Cloud Console, go to APIs & Services > Credentials and create a new OAuth 2.0 Client ID. Select Web application as the application type. Note the Client ID and Client Secret."
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Redirect URI",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the OAuth client settings, add the following URL to the Authorized redirect URIs."
+        },
+        {
+          "type": "copy",
+          "label": "Redirect URI",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Add this to the Authorized redirect URIs in Google Cloud Console"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Client Credentials",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Enter the Client ID and Client Secret from your Google OAuth credentials."
+        },
+        {
+          "type": "formGroup",
+          "id": "googleCreds",
+          "exclusive": false,
+          "forms": [
+            "clientCredentials"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create Google Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create OIDC Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkOidc}}",
+          "adminButtonText": "Manage OIDC Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "clientCredentials": {
+      "title": "Google Credentials",
+      "description": "Enter the OAuth client credentials from Google Cloud Console.",
+      "fields": [
+        {
+          "id": "clientId",
+          "type": "text",
+          "label": "Client ID",
+          "placeholder": "your-client-id.apps.googleusercontent.com",
+          "required": true
+        },
+        {
+          "id": "clientSecret",
+          "type": "password",
+          "label": "Client Secret",
+          "placeholder": "your-client-secret",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Verify & Save",
+        "action": "validateCredentials"
+      }
+    }
+  },
+  "actions": {
+    "validateCredentials": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "https://accounts.google.com/.well-known/openid-configuration",
+        "providerId": "oidc"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED",
+          "CREDENTIALS_PROVIDED"
+        ]
+      },
+      "messages": {
+        "success": "Google OIDC configuration verified. You can now create the identity provider.",
+        "error": "Could not fetch Google OIDC configuration. Please try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "oidc",
+        "hideOnLogin": true,
+        "config": {
+          "syncMode": "FORCE",
+          "clientAuthMethod": "client_secret_post",
+          "clientId": "{{state.formValues.clientId}}",
+          "clientSecret": "{{state.formValues.clientSecret}}",
+          "$spread": "{{state.metadata}}"
+        }
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "Google Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/keycloak/saml.json
+++ b/apps/wizard-v2/wizards/keycloak/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "keycloak-saml",
+  "providerId": "keycloak",
+  "protocol": "saml",
+  "title": "Keycloak SAML",
+  "alias": {
+    "prefix": "keycloak-saml",
+    "sessionKey": "p2_keycloak_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create a SAML Client",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the source Keycloak realm, create a new SAML client. Use the following values for the client configuration."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Use as the Master SAML Processing URL and Valid Redirect URI"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Use as the Client ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "SP SAML Descriptor URL"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Application Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Copy the SAML metadata URL from the source Keycloak realm. This is available at /realms/{realm}/protocol/saml/descriptor."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataUrl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the source Keycloak realm, add protocol mappers to the SAML client to include the following attributes in the assertion."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "username",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "email",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "firstName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "lastName",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Ensure the users who need access exist in the source Keycloak realm, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataUrl": {
+      "title": "Metadata URL",
+      "description": "Paste the SAML metadata URL from the source Keycloak realm.",
+      "fields": [
+        {
+          "id": "url",
+          "type": "url",
+          "label": "Metadata URL",
+          "placeholder": "https://keycloak.example.com/realms/your-realm/protocol/saml/descriptor",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate URL",
+        "action": "validateMetadataUrl"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataUrl": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "{{form.url}}",
+        "providerId": "saml"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata URL validated. Continue to the next step.",
+        "error": "Validation failed. Check the URL and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "username",
+          "friendlyName": "username",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "email",
+          "friendlyName": "email",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "firstName",
+          "friendlyName": "firstName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "lastName",
+          "friendlyName": "lastName",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/logingov/oidc.json
+++ b/apps/wizard-v2/wizards/logingov/oidc.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": "1.0",
+  "id": "logingov-oidc",
+  "providerId": "logingov",
+  "protocol": "oidc",
+  "title": "Login.gov OpenID Connect",
+  "alias": {
+    "prefix": "logingov-oidc",
+    "sessionKey": "p2_logingov_oidc"
+  },
+  "idpConfig": {
+    "providerId": "oidc",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "clientAuthMethod": "private_key_jwt"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Register an Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the Login.gov Developer Portal, create a new application. Login.gov uses private_key_jwt authentication — you will need to generate a public/private key pair and upload the public key certificate to Login.gov. Note the Issuer (your app's unique URI) for use as the Client ID."
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Redirect URI",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In your Login.gov application settings, add the following URL as a redirect URI."
+        },
+        {
+          "type": "copy",
+          "label": "Redirect URI",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Add this as a redirect URI in the Login.gov Developer Portal"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Client Credentials",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Enter your application's Issuer URI (used as the Client ID) and paste the private key (PEM format) that corresponds to the public key certificate you uploaded to Login.gov."
+        },
+        {
+          "type": "formGroup",
+          "id": "logingovCreds",
+          "exclusive": false,
+          "forms": [
+            "clientCredentials"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create Login.gov Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create OIDC Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkOidc}}",
+          "adminButtonText": "Manage OIDC Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "clientCredentials": {
+      "title": "Login.gov Credentials",
+      "description": "Enter your Login.gov application credentials.",
+      "fields": [
+        {
+          "id": "clientId",
+          "type": "text",
+          "label": "Issuer URI (Client ID)",
+          "placeholder": "urn:gov:gsa:openidconnect.profiles:sp:sso:your-agency:your-app",
+          "required": true
+        },
+        {
+          "id": "clientSecret",
+          "type": "password",
+          "label": "Private Key (PEM)",
+          "placeholder": "Paste your private key in PEM format",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Verify & Save",
+        "action": "validateCredentials"
+      }
+    }
+  },
+  "actions": {
+    "validateCredentials": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "https://secure.login.gov/.well-known/openid-configuration",
+        "providerId": "oidc"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED",
+          "CREDENTIALS_PROVIDED"
+        ]
+      },
+      "messages": {
+        "success": "Login.gov OIDC configuration verified. You can now create the identity provider.",
+        "error": "Could not fetch Login.gov OIDC configuration. Please try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "oidc",
+        "hideOnLogin": true,
+        "config": {
+          "syncMode": "FORCE",
+          "clientAuthMethod": "private_key_jwt",
+          "clientId": "{{state.formValues.clientId}}",
+          "clientSecret": "{{state.formValues.clientSecret}}",
+          "$spread": "{{state.metadata}}"
+        }
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "Login.gov Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/miniorange/saml.json
+++ b/apps/wizard-v2/wizards/miniorange/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "miniorange-saml",
+  "providerId": "miniorange",
+  "protocol": "saml",
+  "title": "miniOrange SAML",
+  "alias": {
+    "prefix": "miniorange-saml",
+    "sessionKey": "p2_miniorange_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create a SAML Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In the miniOrange admin console, add a new SAML application. Enter the following service provider details in the application configuration."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Sometimes called SSO Service URL or Callback URL"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Sometimes called Audience URI or SP Entity ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "Sometimes called Entity Provider Metadata or Descriptor URL"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Application Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Copy the IdP metadata URL from the miniOrange SAML application settings."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataUrl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Configure your identity provider to send the following SAML attributes."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "username",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "email",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "firstName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "lastName",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataUrl": {
+      "title": "Metadata URL",
+      "description": "Paste the SAML metadata URL provided by your identity provider.",
+      "fields": [
+        {
+          "id": "url",
+          "type": "url",
+          "label": "Metadata URL",
+          "placeholder": "https://login.xecurify.com/moas/metadata/saml",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate URL",
+        "action": "validateMetadataUrl"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataUrl": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "{{form.url}}",
+        "providerId": "saml"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata URL validated. Continue to the next step.",
+        "error": "Validation failed. Check the URL and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "username",
+          "friendlyName": "username",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "email",
+          "friendlyName": "email",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "firstName",
+          "friendlyName": "firstName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "lastName",
+          "friendlyName": "lastName",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/netiq/saml.json
+++ b/apps/wizard-v2/wizards/netiq/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "netiq-saml",
+  "providerId": "netiq",
+  "protocol": "saml",
+  "title": "NetIQ Access Manager SAML",
+  "alias": {
+    "prefix": "netiq-saml",
+    "sessionKey": "p2_netiq_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create a SAML Service Provider",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In NetIQ Access Manager, create a new SAML 2.0 Service Provider trust. Enter the following values in the service provider configuration."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Sometimes called SSO Service URL or Callback URL"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Sometimes called Audience URI or SP Entity ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "Sometimes called Entity Provider Metadata or Descriptor URL"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Application Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Copy the IdP metadata URL from NetIQ Access Manager. This is typically available at /nidp/saml2/metadata."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataUrl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Configure your identity provider to send the following SAML attributes."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "uid",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "mail",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "givenName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "sn",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataUrl": {
+      "title": "Metadata URL",
+      "description": "Paste the SAML metadata URL provided by your identity provider.",
+      "fields": [
+        {
+          "id": "url",
+          "type": "url",
+          "label": "Metadata URL",
+          "placeholder": "https://your-server.example.com/nidp/saml2/metadata",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate URL",
+        "action": "validateMetadataUrl"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataUrl": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "{{form.url}}",
+        "providerId": "saml"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata URL validated. Continue to the next step.",
+        "error": "Validation failed. Check the URL and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "uid",
+          "friendlyName": "uid",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "mail",
+          "friendlyName": "mail",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "givenName",
+          "friendlyName": "givenName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "sn",
+          "friendlyName": "sn",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/okta/oidc.json
+++ b/apps/wizard-v2/wizards/okta/oidc.json
@@ -1,0 +1,172 @@
+{
+  "schemaVersion": "1.0",
+  "id": "okta-oidc",
+  "providerId": "okta",
+  "protocol": "oidc",
+  "title": "Okta OpenID Connect",
+  "alias": {
+    "prefix": "okta-oidc",
+    "sessionKey": "p2_okta_oidc"
+  },
+  "idpConfig": {
+    "providerId": "oidc",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "clientAuthMethod": "client_secret_post"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create an OIDC Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In Okta, create a new Web Application with the OpenID Connect sign-in method. Note the Okta domain, Client ID, and Client Secret from the application settings."
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Domain & Credentials",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Enter your Okta domain and the client credentials from your application settings. The domain is used to fetch the OpenID Connect configuration automatically."
+        },
+        {
+          "type": "formGroup",
+          "id": "oktaCreds",
+          "exclusive": false,
+          "forms": [
+            "domainCredentials"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Redirect URI",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In your Okta application settings, add the following URL to the Sign-in redirect URIs."
+        },
+        {
+          "type": "copy",
+          "label": "Redirect URI",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Add this to the Sign-in redirect URIs in Okta"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create Okta Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create OIDC Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkOidc}}",
+          "adminButtonText": "Manage OIDC Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "domainCredentials": {
+      "title": "Okta Credentials",
+      "description": "Enter your Okta domain and client credentials.",
+      "fields": [
+        {
+          "id": "domain",
+          "type": "text",
+          "label": "Okta Domain",
+          "placeholder": "your-org.okta.com",
+          "required": true
+        },
+        {
+          "id": "clientId",
+          "type": "text",
+          "label": "Client ID",
+          "placeholder": "your-client-id",
+          "required": true
+        },
+        {
+          "id": "clientSecret",
+          "type": "password",
+          "label": "Client Secret",
+          "placeholder": "your-client-secret",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Verify & Save",
+        "action": "validateDomainCredentials"
+      }
+    }
+  },
+  "actions": {
+    "validateDomainCredentials": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "https://{{form.domain}}/.well-known/openid-configuration",
+        "providerId": "oidc"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED",
+          "CREDENTIALS_PROVIDED"
+        ]
+      },
+      "messages": {
+        "success": "Okta configuration verified. Continue to set the redirect URI.",
+        "error": "Could not fetch configuration. Check the Okta domain and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "oidc",
+        "hideOnLogin": true,
+        "config": {
+          "syncMode": "FORCE",
+          "clientAuthMethod": "client_secret_post",
+          "clientId": "{{state.formValues.clientId}}",
+          "clientSecret": "{{state.formValues.clientSecret}}",
+          "$spread": "{{state.metadata}}"
+        }
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "Okta Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/pingfederate/saml.json
+++ b/apps/wizard-v2/wizards/pingfederate/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "pingfederate-saml",
+  "providerId": "pingfederate",
+  "protocol": "saml",
+  "title": "PingFederate SAML",
+  "alias": {
+    "prefix": "pingfederate-saml",
+    "sessionKey": "p2_pingfederate_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create a SAML Connection",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In PingFederate, create a new SP Connection using the SAML 2.0 Browser SSO profile. Enter the following service provider details in the connection configuration."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Sometimes called SSO Service URL or Callback URL"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Sometimes called Audience URI or SP Entity ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "Sometimes called Entity Provider Metadata or Descriptor URL"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Application Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Copy the PingFederate IdP metadata URL. This is typically available at your PingFederate server under /pf/federation_metadata.ping?PartnerSpId=YOUR_SP_ENTITY_ID."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataUrl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In PingFederate, configure the Attribute Contract to send the following SAML attributes in the assertion."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "username",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "email",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "firstName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "lastName",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataUrl": {
+      "title": "Metadata URL",
+      "description": "Paste the SAML metadata URL provided by your identity provider.",
+      "fields": [
+        {
+          "id": "url",
+          "type": "url",
+          "label": "Metadata URL",
+          "placeholder": "https://pingfederate.example.com/pf/federation_metadata.ping",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate URL",
+        "action": "validateMetadataUrl"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataUrl": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "{{form.url}}",
+        "providerId": "saml"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata URL validated. Continue to the next step.",
+        "error": "Validation failed. Check the URL and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "username",
+          "friendlyName": "username",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "email",
+          "friendlyName": "email",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "firstName",
+          "friendlyName": "firstName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "lastName",
+          "friendlyName": "lastName",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/rippling/saml.json
+++ b/apps/wizard-v2/wizards/rippling/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "rippling-saml",
+  "providerId": "rippling",
+  "protocol": "saml",
+  "title": "Rippling SAML",
+  "alias": {
+    "prefix": "rippling-saml",
+    "sessionKey": "p2_rippling_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create a SAML Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In Rippling, navigate to the App Shop and create a custom SAML application. Enter the following service provider details in the SAML settings."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Sometimes called SSO Service URL or Callback URL"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Sometimes called Audience URI or SP Entity ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "Sometimes called Entity Provider Metadata or Descriptor URL"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Upload Identity Provider Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Download the IdP metadata XML from Rippling and upload it here. You can find this in the SAML application settings."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataFile"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Configure your identity provider to send the following SAML attributes."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "username",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "email",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "firstName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "lastName",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataFile": {
+      "title": "Metadata File",
+      "description": "Upload the SAML metadata XML file from your identity provider.",
+      "fields": [
+        {
+          "id": "file",
+          "type": "file",
+          "label": "Metadata File",
+          "accept": "text/xml,application/xml,.xml",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate File",
+        "action": "validateMetadataFile"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataFile": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "multipart",
+      "body": {
+        "providerId": "saml",
+        "file": "{{form.file}}"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata file validated. Continue to the next step.",
+        "error": "Validation failed. Check the file and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "username",
+          "friendlyName": "username",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "email",
+          "friendlyName": "email",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "firstName",
+          "friendlyName": "firstName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "lastName",
+          "friendlyName": "lastName",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/shibboleth/saml.json
+++ b/apps/wizard-v2/wizards/shibboleth/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "shibboleth-saml",
+  "providerId": "shibboleth",
+  "protocol": "saml",
+  "title": "Shibboleth SAML",
+  "alias": {
+    "prefix": "shibboleth-saml",
+    "sessionKey": "p2_shibboleth_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Register a SAML Service Provider",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Register a new SAML service provider in your Shibboleth IdP metadata configuration. Use the following values."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Sometimes called SSO Service URL or Callback URL"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Sometimes called Audience URI or SP Entity ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "You can import this URL directly in your Shibboleth metadata-providers.xml"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Upload Identity Provider Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Download the Shibboleth IdP metadata XML. This is typically available at /idp/shibboleth or /idp/profile/Metadata/SAML on your Shibboleth server."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataFile"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Configure the Shibboleth attribute resolver and filter to release the following attributes to this service provider."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "uid",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "mail",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "givenName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "sn",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Ensure the users who need access exist in the identity provider's directory, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataFile": {
+      "title": "Metadata File",
+      "description": "Upload the SAML metadata XML file from your identity provider.",
+      "fields": [
+        {
+          "id": "file",
+          "type": "file",
+          "label": "Metadata File",
+          "accept": "text/xml,application/xml,.xml",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate File",
+        "action": "validateMetadataFile"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataFile": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "multipart",
+      "body": {
+        "providerId": "saml",
+        "file": "{{form.file}}"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata file validated. Continue to the next step.",
+        "error": "Validation failed. Check the file and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "uid",
+          "friendlyName": "uid",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "mail",
+          "friendlyName": "mail",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "givenName",
+          "friendlyName": "givenName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "sn",
+          "friendlyName": "sn",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/simplesamlphp/saml.json
+++ b/apps/wizard-v2/wizards/simplesamlphp/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "simplesamlphp-saml",
+  "providerId": "simplesamlphp",
+  "protocol": "saml",
+  "title": "SimpleSAMLphp SAML",
+  "alias": {
+    "prefix": "simplesamlphp-saml",
+    "sessionKey": "p2_simplesamlphp_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Register a SAML Service Provider",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In SimpleSAMLphp, add a new SP entry in metadata/saml20-sp-remote.php. Use the following values for the service provider configuration."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Use as the AssertionConsumerService Location"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Use as the entityid key in the SP metadata array"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "You can use this URL to auto-configure the SP metadata"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Application Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Copy the SimpleSAMLphp IdP metadata URL. This is typically available at /simplesaml/saml2/idp/metadata.php."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataUrl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Configure the SimpleSAMLphp authentication source and attribute release to include the following attributes."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "uid",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "mail",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "givenName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "sn",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Ensure the users who need access exist in the identity provider's authentication source, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataUrl": {
+      "title": "Metadata URL",
+      "description": "Paste the SAML metadata URL provided by your identity provider.",
+      "fields": [
+        {
+          "id": "url",
+          "type": "url",
+          "label": "Metadata URL",
+          "placeholder": "https://your-server.example.com/simplesaml/saml2/idp/metadata.php",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate URL",
+        "action": "validateMetadataUrl"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataUrl": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "{{form.url}}",
+        "providerId": "saml"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata URL validated. Continue to the next step.",
+        "error": "Validation failed. Check the URL and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "uid",
+          "friendlyName": "uid",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "mail",
+          "friendlyName": "mail",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "givenName",
+          "friendlyName": "givenName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "sn",
+          "friendlyName": "sn",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}

--- a/apps/wizard-v2/wizards/vmware/saml.json
+++ b/apps/wizard-v2/wizards/vmware/saml.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "id": "vmware-saml",
+  "providerId": "vmware",
+  "protocol": "saml",
+  "title": "VMware Workspace ONE SAML",
+  "alias": {
+    "prefix": "vmware-saml",
+    "sessionKey": "p2_vmware_saml"
+  },
+  "idpConfig": {
+    "providerId": "saml",
+    "hideOnLogin": true,
+    "defaults": {
+      "syncMode": "FORCE",
+      "allowCreate": "true",
+      "nameIDPolicyFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+      "principalType": "SUBJECT"
+    }
+  },
+  "steps": [
+    {
+      "id": 1,
+      "title": "Create a SAML Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "In VMware Workspace ONE Access, create a new SAML application. Enter the following service provider details in the application configuration."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Sometimes called SSO Service URL or Callback URL"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID",
+          "value": "{{api.entityId}}",
+          "hint": "Sometimes called Audience URI or SP Entity ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "Sometimes called Entity Provider Metadata or Descriptor URL"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure Application Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Copy the IdP metadata URL from VMware Workspace ONE Access. This is typically found in the identity provider settings under SAML Metadata."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataUrl"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Attribute Mapping",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Configure your identity provider to send the following SAML attributes."
+        },
+        {
+          "type": "attributeTable",
+          "rows": [
+            {
+              "idpAttribute": "username",
+              "keycloakAttribute": "username"
+            },
+            {
+              "idpAttribute": "email",
+              "keycloakAttribute": "email"
+            },
+            {
+              "idpAttribute": "firstName",
+              "keycloakAttribute": "firstName"
+            },
+            {
+              "idpAttribute": "lastName",
+              "keycloakAttribute": "lastName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure User Access",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Confirmation",
+      "type": "confirm",
+      "blocks": [
+        {
+          "type": "confirm",
+          "title": "Create SAML Identity Provider",
+          "description": "Configuration is complete. Click the button below to create the identity provider in Keycloak.",
+          "buttonText": "Create SAML Identity Provider",
+          "action": "createIdp",
+          "adminLink": "{{api.adminLinkSaml}}",
+          "adminButtonText": "Manage SAML Identity Provider"
+        }
+      ]
+    }
+  ],
+  "forms": {
+    "metadataUrl": {
+      "title": "Metadata URL",
+      "description": "Paste the SAML metadata URL provided by your identity provider.",
+      "fields": [
+        {
+          "id": "url",
+          "type": "url",
+          "label": "Metadata URL",
+          "placeholder": "https://your-tenant.vmwareidentity.com/SAAS/API/1.0/GET/metadata/idp.xml",
+          "required": true
+        }
+      ],
+      "submit": {
+        "label": "Validate URL",
+        "action": "validateMetadataUrl"
+      }
+    }
+  },
+  "actions": {
+    "validateMetadataUrl": {
+      "endpoint": "importConfig",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "fromUrl": "{{form.url}}",
+        "providerId": "saml"
+      },
+      "onSuccess": {
+        "mergeIntoMetadata": "{{response}}",
+        "dispatch": [
+          "METADATA_VALIDATED"
+        ]
+      },
+      "messages": {
+        "success": "Metadata URL validated. Continue to the next step.",
+        "error": "Validation failed. Check the URL and try again."
+      }
+    },
+    "createIdp": {
+      "endpoint": "createIdp",
+      "method": "POST",
+      "contentType": "json",
+      "body": {
+        "alias": "{{alias}}",
+        "displayName": "{{alias}}",
+        "providerId": "saml",
+        "hideOnLogin": true,
+        "config": "{{state.metadata}}"
+      },
+      "onSuccess": {
+        "dispatch": [
+          {
+            "type": "SUBMIT_SUCCESS",
+            "result": "SAML Identity Provider created successfully."
+          }
+        ],
+        "then": [
+          "addSamlMappers",
+          "clearAlias"
+        ]
+      },
+      "messages": {
+        "error": "Error creating Identity Provider. One may already be configured for this realm."
+      }
+    },
+    "addSamlMappers": {
+      "endpoint": "addMappers",
+      "method": "POST",
+      "contentType": "json",
+      "foreach": [
+        {
+          "attributeName": "username",
+          "friendlyName": "username",
+          "userAttribute": "username"
+        },
+        {
+          "attributeName": "email",
+          "friendlyName": "email",
+          "userAttribute": "email"
+        },
+        {
+          "attributeName": "firstName",
+          "friendlyName": "firstName",
+          "userAttribute": "firstName"
+        },
+        {
+          "attributeName": "lastName",
+          "friendlyName": "lastName",
+          "userAttribute": "lastName"
+        }
+      ],
+      "body": {
+        "identityProviderAlias": "{{alias}}",
+        "identityProviderMapper": "saml-user-attribute-idp-mapper",
+        "name": "{{item.userAttribute}}",
+        "config": {
+          "syncMode": "INHERIT",
+          "attributes": "[]",
+          "attribute.name": "{{item.attributeName}}",
+          "attribute.friendly.name": "{{item.friendlyName}}",
+          "user.attribute": "{{item.userAttribute}}"
+        }
+      }
+    },
+    "clearAlias": {
+      "type": "clearAlias"
+    }
+  }
+}


### PR DESCRIPTION
Issue: #262

## Changes Made
- 10 new SAML wizards: PingFederate, VMware, Keycloak, Rippling, ClassLink, miniOrange, NetIQ, CAS, Shibboleth, SimpleSAMLphp
- 6 new OIDC wizards: Okta, Entra ID, Google, Clever, ADP, Login.gov
- Updated provider registry with all new entries


