### PR TITLE
New IdP wizards: SAML and OIDC (Phase 1 & 2)

### DIFF
--- a/apps/wizard-v2/README.md
+++ b/apps/wizard-v2/README.md
@@ -420,3 +420,13 @@ Output goes to `dist/`. When wizard-v2 is ready for production, the root `pom.xm
 
 - AWS: complete
 - Microsoft Entra ID: complete
+- ADFS: complete
+- Oracle: complete
+- Salesforce (SAML): complete
+- JumpCloud: complete
+- Okta (SAML): complete
+- Cloudflare: complete
+- LastPass: complete
+- OneLogin: complete
+- CyberArk: complete
+- Google Workspace (SAML): complete

--- a/apps/wizard-v2/wizards/adfs/saml.json
+++ b/apps/wizard-v2/wizards/adfs/saml.json
@@ -24,56 +24,34 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Open AD FS Management",
       "blocks": [
         {
           "type": "text",
-          "content": "In the AD FS Management console, set up a Relying Party Trust. Enter the following values."
-        },
-        {
-          "type": "copy",
-          "label": "ACS URL",
-          "value": "{{api.ssoUrl}}",
-          "hint": "Sometimes called SSO Service URL or Callback URL"
-        },
-        {
-          "type": "copy",
-          "label": "Entity ID",
-          "value": "{{api.entityId}}",
-          "hint": "Sometimes called Audience URI or SP Entity ID"
-        },
-        {
-          "type": "copy",
-          "label": "SAML Metadata URL",
-          "value": "{{api.samlMetadata}}",
-          "hint": "Sometimes called Entity Provider Metadata or Descriptor URL"
+          "content": "On your AD FS server, open the AD FS Management console from Server Manager → Tools → AD FS Management."
         },
         {
           "type": "image",
           "src": "/wizards/adfs/saml/adfs_saml_0.png"
         },
         {
+          "type": "text",
+          "content": "In the left sidebar, expand \"Relying Party Trusts\", then click \"Add Relying Party Trust...\" in the Actions panel on the right."
+        },
+        {
           "type": "image",
           "src": "/wizards/adfs/saml/adfs_saml_1.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/adfs/saml/adfs_saml_2.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/adfs/saml/adfs_saml_3.png"
         }
       ]
     },
     {
       "id": 2,
-      "title": "Configure Application Metadata",
+      "title": "Import AD FS Metadata into Keycloak",
       "enableNextWhen": "state.metadataValidated",
       "blocks": [
         {
           "type": "text",
-          "content": "Enter the metadata URL provided by your AD FS server."
+          "content": "Copy the AD FS federation metadata URL from your server. It is typically located at https://your-adfs-server/federationmetadata/2007-06/federationmetadata.xml. Paste it into the form below to import the AD FS configuration."
         },
         {
           "type": "image",
@@ -91,14 +69,106 @@
     },
     {
       "id": 3,
-      "title": "Configure Attribute Mapping",
+      "title": "Configure the Relying Party Trust",
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "Back in AD FS Management, in the Add Relying Party Trust wizard, choose \"Claims aware\" and click \"Start\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/adfs/saml/adfs_saml_2.png"
+        },
+        {
+          "type": "text",
+          "content": "On the \"Select Data Source\" step, choose \"Enter data about the relying party manually\" and click \"Next\". Use the following values when prompted by the wizard."
+        },
+        {
+          "type": "copy",
+          "label": "ACS URL",
+          "value": "{{api.ssoUrl}}",
+          "hint": "Sometimes called SSO Service URL or Callback URL"
+        },
+        {
+          "type": "copy",
+          "label": "Entity ID (Relying Party Trust Identifier)",
+          "value": "{{api.entityId}}",
+          "hint": "Sometimes called Audience URI or SP Entity ID"
+        },
+        {
+          "type": "copy",
+          "label": "SAML Metadata URL",
+          "value": "{{api.samlMetadata}}",
+          "hint": "Sometimes called Entity Provider Metadata or Descriptor URL"
+        },
+        {
+          "type": "image",
+          "src": "/wizards/adfs/saml/adfs_saml_3.png"
+        },
+        {
+          "type": "text",
+          "content": "Specify a display name for the relying party, then click \"Next\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/adfs/saml/adfs_saml_4.png"
+        },
+        {
+          "type": "text",
+          "content": "On the \"Configure URL\" step, check \"Enable support for the SAML 2.0 WebSSO protocol\" and paste the ACS URL above as the Relying party SAML 2.0 SSO service URL."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/adfs/saml/adfs_saml_5.png"
+        },
+        {
+          "type": "text",
+          "content": "On the \"Configure Identifiers\" step, paste the Entity ID above into the Relying party trust identifier field, click \"Add\", then \"Next\" to continue. Complete the rest of the wizard, accepting the defaults."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/adfs/saml/adfs_saml_6.png"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Configure Claim Issuance Policy",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "After finishing the wizard, right-click the new Relying Party Trust and select \"Edit Claim Issuance Policy...\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/adfs/saml/adfs_saml_7.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Add Rule...\" to launch the Add Transform Claim Rule Wizard."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/adfs/saml/adfs_saml_8.png"
+        },
+        {
+          "type": "text",
+          "content": "From the \"Claim rule template\" dropdown, select \"Send LDAP Attributes as Claims\" and click \"Next\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/adfs/saml/adfs_saml_9.png"
+        },
+        {
+          "type": "text",
+          "content": "Enter a claim rule name (for example, \"Send User Attributes\") and choose \"Active Directory\" as the Attribute store. Map the following LDAP attributes to the corresponding Outgoing Claim Type URIs:"
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "ADFS Claim URI",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "http://schemas.microsoft.com/2012/12/certificatecontext/field/subjectname",
@@ -120,49 +190,23 @@
         },
         {
           "type": "image",
-          "src": "/wizards/adfs/saml/adfs_saml_7.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/adfs/saml/adfs_saml_8.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/adfs/saml/adfs_saml_9.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/adfs/saml/adfs_saml_10.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Finish\" to save the claim rule."
         },
         {
           "type": "image",
           "src": "/wizards/adfs/saml/adfs_saml_11.png"
         },
         {
+          "type": "text",
+          "content": "Verify the rule appears in the \"Issuance Transform Rules\" list, then click \"OK\"."
+        },
+        {
           "type": "image",
           "src": "/wizards/adfs/saml/adfs_saml_12.png"
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "title": "Configure User Access",
-      "blocks": [
-        {
-          "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
-        },
-        {
-          "type": "image",
-          "src": "/wizards/adfs/saml/adfs_saml_4.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/adfs/saml/adfs_saml_5.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/adfs/saml/adfs_saml_6.png"
         }
       ]
     },

--- a/apps/wizard-v2/wizards/auth0/saml.json
+++ b/apps/wizard-v2/wizards/auth0/saml.json
@@ -100,6 +100,10 @@
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "WS-Fed Claim URI",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/username",

--- a/apps/wizard-v2/wizards/cloudflare/saml.json
+++ b/apps/wizard-v2/wizards/cloudflare/saml.json
@@ -21,11 +21,41 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Open Cloudflare Zero Trust",
       "blocks": [
         {
           "type": "text",
-          "content": "In Cloudflare Zero Trust, create a new SAML application. Enter the following values in the SAML settings."
+          "content": "Sign in to the Cloudflare dashboard and open the Zero Trust dashboard."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/cloudflare/saml/cloudflare_saml_0.png"
+        },
+        {
+          "type": "text",
+          "content": "Navigate to Settings → Authentication."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/cloudflare/saml/cloudflare_saml_1.png"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Add a SAML Login Method",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Under \"Login methods\", click \"Add new\" and select \"SAML\" as the identity provider type."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/cloudflare/saml/cloudflare_saml_2.png"
+        },
+        {
+          "type": "text",
+          "content": "Enter a name for the login method, then fill in the following service provider values."
         },
         {
           "type": "copy",
@@ -47,34 +77,26 @@
         },
         {
           "type": "image",
-          "src": "/wizards/cloudflare/saml/cloudflare_saml_0.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/cloudflare/saml/cloudflare_saml_1.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/cloudflare/saml/cloudflare_saml_2.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/cloudflare/saml/cloudflare_saml_3.png"
         }
       ]
     },
     {
-      "id": 2,
-      "title": "Configure Application Metadata",
+      "id": 3,
+      "title": "Import Cloudflare Metadata",
       "enableNextWhen": "state.metadataValidated",
       "blocks": [
         {
           "type": "text",
-          "content": "Enter the metadata URL provided by Cloudflare after saving the application."
+          "content": "After saving, Cloudflare displays the IdP metadata URL on the login method page. Copy it from the integration details."
         },
         {
           "type": "image",
           "src": "/wizards/cloudflare/saml/cloudflare_saml_4.png"
+        },
+        {
+          "type": "text",
+          "content": "Paste the metadata URL below to import the Cloudflare IdP configuration into Keycloak."
         },
         {
           "type": "formGroup",
@@ -87,15 +109,19 @@
       ]
     },
     {
-      "id": 3,
-      "title": "Configure Attribute Mapping",
+      "id": 4,
+      "title": "Configure SAML Attributes",
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "In the Cloudflare SAML login method settings, configure the SAML attribute mappings so the following claims are included in the assertion."
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "SAML Attribute Name",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "username",
@@ -122,20 +148,28 @@
       ]
     },
     {
-      "id": 4,
-      "title": "Configure User Access",
+      "id": 5,
+      "title": "Configure Access Policies",
       "blocks": [
         {
           "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+          "content": "In Zero Trust, open Access → Applications and create or edit an application that uses this login method."
         },
         {
           "type": "image",
           "src": "/wizards/cloudflare/saml/cloudflare_saml_6.png"
         },
         {
+          "type": "text",
+          "content": "Define the access policy rules that determine which users can authenticate through this SAML login method."
+        },
+        {
           "type": "image",
           "src": "/wizards/cloudflare/saml/cloudflare_saml_7.png"
+        },
+        {
+          "type": "text",
+          "content": "Save the policy. Cloudflare will now route authentication requests through this SAML connection."
         },
         {
           "type": "image",
@@ -144,7 +178,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "title": "Confirmation",
       "type": "confirm",
       "blocks": [

--- a/apps/wizard-v2/wizards/cyberark/saml.json
+++ b/apps/wizard-v2/wizards/cyberark/saml.json
@@ -21,21 +21,51 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Add a SAML Web App in CyberArk Identity",
       "blocks": [
         {
           "type": "text",
-          "content": "In the CyberArk Identity Admin Portal, create a new SAML application. Enter the following service provider details."
+          "content": "Sign in to the CyberArk Identity Admin Portal and open Apps → Web Apps."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/cyberark/SAML/cyberark_saml_0.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Add Web Apps\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/cyberark/SAML/cyberark_saml_1.png"
+        },
+        {
+          "type": "text",
+          "content": "Switch to the \"Custom\" tab, locate \"SAML\", and click \"Add\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/cyberark/SAML/cyberark_saml_2.png"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure the SAML Trust",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Open the \"Trust\" tab on the new app and enter the following service provider values."
         },
         {
           "type": "copy",
-          "label": "ACS URL",
+          "label": "ACS URL (Assertion Consumer Service URL)",
           "value": "{{api.ssoUrl}}",
           "hint": "Sometimes called SSO Service URL or Callback URL"
         },
         {
           "type": "copy",
-          "label": "Entity ID",
+          "label": "Entity ID (SP Entity ID)",
           "value": "{{api.entityId}}",
           "hint": "Sometimes called Audience URI or SP Entity ID"
         },
@@ -47,34 +77,26 @@
         },
         {
           "type": "image",
-          "src": "/wizards/cyberark/SAML/cyberark_saml_0.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/cyberark/SAML/cyberark_saml_1.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/cyberark/SAML/cyberark_saml_2.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/cyberark/SAML/cyberark_saml_4.png"
         }
       ]
     },
     {
-      "id": 2,
-      "title": "Configure Application Metadata",
+      "id": 3,
+      "title": "Import CyberArk IdP Metadata",
       "enableNextWhen": "state.metadataValidated",
       "blocks": [
         {
           "type": "text",
-          "content": "Enter the SAML metadata URL from CyberArk."
+          "content": "In the same Trust tab, scroll to the Identity Provider Configuration section and copy the metadata URL."
         },
         {
           "type": "image",
           "src": "/wizards/cyberark/SAML/cyberark_saml_3.png"
+        },
+        {
+          "type": "text",
+          "content": "Paste the metadata URL below to import the CyberArk IdP configuration into Keycloak."
         },
         {
           "type": "formGroup",
@@ -87,15 +109,19 @@
       ]
     },
     {
-      "id": 3,
+      "id": 4,
       "title": "Configure Attribute Mapping",
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "Open the \"SAML Response\" tab and add the following Attribute statements so user details are included in the assertion."
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "SAML Attribute Name",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "username",
@@ -122,16 +148,20 @@
       ]
     },
     {
-      "id": 4,
-      "title": "Configure User Access",
+      "id": 5,
+      "title": "Assign Permissions",
       "blocks": [
         {
           "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+          "content": "Open the \"Permissions\" tab and click \"Add\" to grant Run and View access to the appropriate users or roles."
         },
         {
           "type": "image",
           "src": "/wizards/cyberark/SAML/cyberark_saml_6.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Save\" to commit the permission assignments."
         },
         {
           "type": "image",
@@ -140,7 +170,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "title": "Confirmation",
       "type": "confirm",
       "blocks": [

--- a/apps/wizard-v2/wizards/duo/saml.json
+++ b/apps/wizard-v2/wizards/duo/saml.json
@@ -88,6 +88,10 @@
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "SAML Attribute Name",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "username",

--- a/apps/wizard-v2/wizards/google/saml.json
+++ b/apps/wizard-v2/wizards/google/saml.json
@@ -21,11 +21,68 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Add a Custom SAML App",
       "blocks": [
         {
           "type": "text",
-          "content": "In the Google Admin console, navigate to Apps → Web and mobile apps → Add App → Add custom SAML app. Enter the following values."
+          "content": "Sign in to the Google Admin Console and navigate to Apps → Web and mobile apps."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/google/google_saml_1a.png"
+        },
+        {
+          "type": "text",
+          "content": "Click the \"Add app\" dropdown and select \"Add custom SAML app\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/google/google_saml_1b.png"
+        },
+        {
+          "type": "text",
+          "content": "Enter an App name (and optional description and logo), then click \"Continue\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/google/google_saml_2.png"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Download Google IdP Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "On the \"Google Identity Provider details\" step, click \"DOWNLOAD METADATA\" to save the IdP metadata XML file."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/google/google_saml_3.png"
+        },
+        {
+          "type": "text",
+          "content": "Upload the downloaded file below to import the Google IdP configuration into Keycloak, then click \"Continue\" in Google."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataFile"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Service Provider Details",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "On the \"Service provider details\" step, enter the following values from Keycloak."
         },
         {
           "type": "copy",
@@ -47,55 +104,28 @@
         },
         {
           "type": "image",
-          "src": "/wizards/google/google_saml_1a.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/google/google_saml_1b.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/google/google_saml_2.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/google/google_saml_4.png"
-        }
-      ]
-    },
-    {
-      "id": 2,
-      "title": "Upload Identity Provider Metadata",
-      "enableNextWhen": "state.metadataValidated",
-      "blocks": [
+        },
         {
           "type": "text",
-          "content": "Download the IdP metadata XML file from Google and upload it here."
-        },
-        {
-          "type": "image",
-          "src": "/wizards/google/google_saml_3.png"
-        },
-        {
-          "type": "formGroup",
-          "id": "metadataInput",
-          "exclusive": false,
-          "forms": [
-            "metadataFile"
-          ]
+          "content": "Leave the Name ID format set to UNSPECIFIED and Name ID set to \"Basic Information > Primary email\". Click \"Continue\"."
         }
       ]
     },
     {
-      "id": 3,
+      "id": 4,
       "title": "Configure Attribute Mapping",
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "On the \"Attribute mapping\" step, click \"Add mapping\" for each of the following entries."
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "LDAP Attribute",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "uid",
@@ -118,20 +148,28 @@
         {
           "type": "image",
           "src": "/wizards/google/google_saml_5.png"
+        },
+        {
+          "type": "text",
+          "content": "Map each Google Directory attribute (Primary email, First name, Last name) to its corresponding App attribute, then click \"Finish\"."
         }
       ]
     },
     {
-      "id": 4,
-      "title": "Configure User Access",
+      "id": 5,
+      "title": "Enable Service for Users",
       "blocks": [
         {
           "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+          "content": "On the new app's page, click the \"User access\" panel."
         },
         {
           "type": "image",
           "src": "/wizards/google/google_saml_6a.png"
+        },
+        {
+          "type": "text",
+          "content": "Choose \"ON for everyone\" or scope access to specific organizational units, then click \"Save\"."
         },
         {
           "type": "image",
@@ -140,7 +178,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "title": "Confirmation",
       "type": "confirm",
       "blocks": [

--- a/apps/wizard-v2/wizards/jumpcloud/saml.json
+++ b/apps/wizard-v2/wizards/jumpcloud/saml.json
@@ -21,11 +21,41 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Add a Custom SAML Application",
       "blocks": [
         {
           "type": "text",
-          "content": "In JumpCloud, create a new custom SAML application. Enter the following values in the SSO configuration."
+          "content": "Sign in to the JumpCloud admin console and navigate to \"SSO Applications\" in the left sidebar."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/jumpcloud/jumpcloud_saml_1.png"
+        },
+        {
+          "type": "text",
+          "content": "Click the \"+ Add New Application\" button at the top of the page."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/jumpcloud/jumpcloud_saml_2.png"
+        },
+        {
+          "type": "text",
+          "content": "Search for or scroll to find \"Custom SAML App\" and click \"Configure\" to add it."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/jumpcloud/jumpcloud_saml_3.png"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure SAML Service Provider Settings",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Open the \"SSO\" tab and enter the following service provider values."
         },
         {
           "type": "copy",
@@ -35,7 +65,7 @@
         },
         {
           "type": "copy",
-          "label": "Entity ID",
+          "label": "Entity ID (SP Entity ID)",
           "value": "{{api.entityId}}",
           "hint": "Sometimes called Audience URI or SP Entity ID"
         },
@@ -47,19 +77,11 @@
         },
         {
           "type": "image",
-          "src": "/wizards/jumpcloud/jumpcloud_saml_1.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/jumpcloud/jumpcloud_saml_2.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/jumpcloud/jumpcloud_saml_3.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/jumpcloud/jumpcloud_saml_4.png"
+        },
+        {
+          "type": "text",
+          "content": "Scroll down and click \"Activate\" to save the application."
         },
         {
           "type": "image",
@@ -68,17 +90,21 @@
       ]
     },
     {
-      "id": 2,
-      "title": "Upload Identity Provider Metadata",
+      "id": 3,
+      "title": "Download Identity Provider Metadata",
       "enableNextWhen": "state.metadataValidated",
       "blocks": [
         {
           "type": "text",
-          "content": "Download the JumpCloud IdP metadata XML file and upload it here."
+          "content": "Open the application in JumpCloud, switch to the \"SSO\" tab, and click \"Export Metadata\" to download the JumpCloud IdP metadata XML."
         },
         {
           "type": "image",
           "src": "/wizards/jumpcloud/jumpcloud_saml_10.png"
+        },
+        {
+          "type": "text",
+          "content": "Upload the downloaded file below to import the JumpCloud IdP configuration into Keycloak."
         },
         {
           "type": "formGroup",
@@ -91,15 +117,27 @@
       ]
     },
     {
-      "id": 3,
+      "id": 4,
       "title": "Configure Attribute Mapping",
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "Back in the JumpCloud application, scroll to the \"Attributes\" section in the SSO tab and click \"add attribute\" for each mapping."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/jumpcloud/jumpcloud_saml_6.png"
+        },
+        {
+          "type": "text",
+          "content": "Configure the following Service Provider Attribute names so they match what Keycloak expects:"
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "LDAP Attribute",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "uid",
@@ -121,29 +159,33 @@
         },
         {
           "type": "image",
-          "src": "/wizards/jumpcloud/jumpcloud_saml_6.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/jumpcloud/jumpcloud_saml_7.png"
         }
       ]
     },
     {
-      "id": 4,
-      "title": "Configure User Access",
+      "id": 5,
+      "title": "Assign User Access",
       "blocks": [
         {
           "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+          "content": "Switch to the \"User Groups\" tab and select the groups that should have access to this application."
         },
         {
           "type": "image",
           "src": "/wizards/jumpcloud/jumpcloud_saml_8.png"
         },
         {
+          "type": "text",
+          "content": "Alternatively, open the \"Users\" tab and assign individual users."
+        },
+        {
           "type": "image",
           "src": "/wizards/jumpcloud/jumpcloud_saml_9.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Save\" to confirm the assignments."
         },
         {
           "type": "image",
@@ -152,7 +194,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "title": "Confirmation",
       "type": "confirm",
       "blocks": [

--- a/apps/wizard-v2/wizards/lastpass/saml.json
+++ b/apps/wizard-v2/wizards/lastpass/saml.json
@@ -21,11 +21,41 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Enable Identity Provider in LastPass",
       "blocks": [
         {
           "type": "text",
-          "content": "In the LastPass Admin Console, enable the Identity Provider and create a new SAML application. Enter the following values."
+          "content": "Sign in to the LastPass Admin Console and open Applications → SSO apps."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/lastpass/lastpass_saml_0.png"
+        },
+        {
+          "type": "text",
+          "content": "If you haven't already, enable Single Sign-On for your account from the Settings → SSO menu."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/lastpass/lastpass_saml_1.png"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Add a SAML Application",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "From the SSO apps page, click \"Add app\" and search for or select \"Custom SAML\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/lastpass/lastpass_saml_2.png"
+        },
+        {
+          "type": "text",
+          "content": "Enter a Display name and the following service provider values into the SAML configuration fields."
         },
         {
           "type": "copy",
@@ -47,38 +77,34 @@
         },
         {
           "type": "image",
-          "src": "/wizards/lastpass/lastpass_saml_0.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/lastpass/lastpass_saml_1.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/lastpass/lastpass_saml_2.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/lastpass/lastpass_saml_4.png"
         }
       ]
     },
     {
-      "id": 2,
-      "title": "Upload Identity Provider Metadata",
+      "id": 3,
+      "title": "Download LastPass IdP Metadata",
       "enableNextWhen": "state.metadataValidated",
       "blocks": [
         {
           "type": "text",
-          "content": "Download the LastPass IdP metadata file and upload it here."
+          "content": "On the LastPass SSO settings page, locate the \"Identity Provider Information\" section."
         },
         {
           "type": "image",
           "src": "/wizards/lastpass/lastpass_saml_5.png"
         },
         {
+          "type": "text",
+          "content": "Click \"Download Metadata\" to save the IdP metadata XML file."
+        },
+        {
           "type": "image",
           "src": "/wizards/lastpass/lastpass_saml_6.png"
+        },
+        {
+          "type": "text",
+          "content": "Upload the downloaded file below to import the LastPass IdP configuration into Keycloak."
         },
         {
           "type": "formGroup",
@@ -91,15 +117,27 @@
       ]
     },
     {
-      "id": 3,
+      "id": 4,
       "title": "Configure Attribute Mapping",
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "Back in the LastPass app settings, scroll to the Attributes section."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/lastpass/lastpass_saml_7.png"
+        },
+        {
+          "type": "text",
+          "content": "Add the following SAML attribute mappings so user information is included in the assertion."
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "SAML Attribute Name",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "username",
@@ -121,21 +159,17 @@
         },
         {
           "type": "image",
-          "src": "/wizards/lastpass/lastpass_saml_7.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/lastpass/lastpass_saml_8.png"
         }
       ]
     },
     {
-      "id": 4,
-      "title": "Configure User Access",
+      "id": 5,
+      "title": "Assign User Access",
       "blocks": [
         {
           "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+          "content": "Open the application's \"Assigned Users\" tab and add the users or groups who should have access."
         },
         {
           "type": "image",
@@ -144,7 +178,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "title": "Confirmation",
       "type": "confirm",
       "blocks": [

--- a/apps/wizard-v2/wizards/okta/saml.json
+++ b/apps/wizard-v2/wizards/okta/saml.json
@@ -21,21 +21,51 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Create a New SAML Application",
       "blocks": [
         {
           "type": "text",
-          "content": "In Okta, create a new SAML 2.0 application. Enter the following service provider details in the SAML settings."
+          "content": "Sign in to the Okta Admin Console and navigate to Applications → Applications."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/okta/saml/okta_saml_1.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Create App Integration\" to start adding a new application."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/okta/saml/okta_saml_2.png"
+        },
+        {
+          "type": "text",
+          "content": "Select \"SAML 2.0\" as the Sign-in method and click \"Next\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/okta/saml/okta_saml_3.png"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure SAML Service Provider Settings",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "On the \"General Settings\" step, enter an App name and click \"Next\". Then, on the \"Configure SAML\" step, enter the following service provider values."
         },
         {
           "type": "copy",
-          "label": "ACS URL",
+          "label": "Single sign-on URL (ACS URL)",
           "value": "{{api.ssoUrl}}",
           "hint": "Sometimes called SSO Service URL or Callback URL"
         },
         {
           "type": "copy",
-          "label": "Entity ID",
+          "label": "Audience URI (SP Entity ID)",
           "value": "{{api.entityId}}",
           "hint": "Sometimes called Audience URI or SP Entity ID"
         },
@@ -47,50 +77,15 @@
         },
         {
           "type": "image",
-          "src": "/wizards/okta/saml/okta_saml_1.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/okta/saml/okta_saml_2.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/okta/saml/okta_saml_3.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/okta/saml/okta_saml_4.png"
+        },
+        {
+          "type": "text",
+          "content": "Leave the remaining defaults and scroll to the Attribute Statements section in the next step."
         },
         {
           "type": "image",
           "src": "/wizards/okta/saml/okta_saml_6.png"
-        }
-      ]
-    },
-    {
-      "id": 2,
-      "title": "Upload Identity Provider Metadata",
-      "enableNextWhen": "state.metadataValidated",
-      "blocks": [
-        {
-          "type": "text",
-          "content": "Download the Okta IdP metadata XML from the Sign On tab and upload it here."
-        },
-        {
-          "type": "image",
-          "src": "/wizards/okta/saml/okta_saml_8.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/okta/saml/okta_saml_9.png"
-        },
-        {
-          "type": "formGroup",
-          "id": "metadataInput",
-          "exclusive": false,
-          "forms": [
-            "metadataFile"
-          ]
         }
       ]
     },
@@ -100,10 +95,14 @@
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "In the \"Attribute Statements\" section, add the following entries so Okta sends user attributes in the SAML assertion."
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "Okta Attribute",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "id",
@@ -126,20 +125,63 @@
         {
           "type": "image",
           "src": "/wizards/okta/saml/okta_saml_5.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Next\", choose \"I'm an Okta customer adding an internal app\" on the Feedback step, then click \"Finish\"."
         }
       ]
     },
     {
       "id": 4,
-      "title": "Configure User Access",
+      "title": "Download Okta IdP Metadata",
+      "enableNextWhen": "state.metadataValidated",
       "blocks": [
         {
           "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+          "content": "After saving the application, open the \"Sign On\" tab."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/okta/saml/okta_saml_8.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"View SAML setup instructions\" or right-click \"Identity Provider metadata\" and copy/save the metadata XML."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/okta/saml/okta_saml_9.png"
+        },
+        {
+          "type": "text",
+          "content": "Upload the metadata file below to import the Okta IdP configuration into Keycloak."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataFile"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Assign Users and Groups",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Switch to the \"Assignments\" tab and click \"Assign\" → \"Assign to People\" or \"Assign to Groups\"."
         },
         {
           "type": "image",
           "src": "/wizards/okta/saml/okta_saml_7.png"
+        },
+        {
+          "type": "text",
+          "content": "Select the users or groups who should have access, then click \"Done\"."
         },
         {
           "type": "image",
@@ -148,7 +190,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "title": "Confirmation",
       "type": "confirm",
       "blocks": [

--- a/apps/wizard-v2/wizards/onelogin/saml.json
+++ b/apps/wizard-v2/wizards/onelogin/saml.json
@@ -21,21 +21,51 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Add a SAML Application",
       "blocks": [
         {
           "type": "text",
-          "content": "In OneLogin, create a new SAML application. Enter the following service provider details."
+          "content": "Sign in to the OneLogin Administration portal and navigate to Applications → Applications."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/onelogin/saml/onelogin_saml_1.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Add App\" and search for \"SAML Custom Connector (Advanced)\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/onelogin/saml/onelogin_saml_2.png"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure SAML Service Provider Settings",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Enter a Display name, then click \"Save\". Switch to the \"Configuration\" tab."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/onelogin/saml/onelogin_saml_3.png"
+        },
+        {
+          "type": "text",
+          "content": "Enter the following service provider values into the Configuration fields."
         },
         {
           "type": "copy",
-          "label": "ACS URL",
+          "label": "ACS (Consumer) URL",
           "value": "{{api.ssoUrl}}",
           "hint": "Sometimes called SSO Service URL or Callback URL"
         },
         {
           "type": "copy",
-          "label": "Entity ID",
+          "label": "Audience (EntityID)",
           "value": "{{api.entityId}}",
           "hint": "Sometimes called Audience URI or SP Entity ID"
         },
@@ -47,34 +77,26 @@
         },
         {
           "type": "image",
-          "src": "/wizards/onelogin/saml/onelogin_saml_1.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/onelogin/saml/onelogin_saml_2.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/onelogin/saml/onelogin_saml_3.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/onelogin/saml/onelogin_saml_4.png"
         }
       ]
     },
     {
-      "id": 2,
-      "title": "Configure Application Metadata",
+      "id": 3,
+      "title": "Import OneLogin IdP Metadata",
       "enableNextWhen": "state.metadataValidated",
       "blocks": [
         {
           "type": "text",
-          "content": "Enter the metadata URL from OneLogin's SSO settings."
+          "content": "On the application's \"SSO\" tab, click \"More Actions\" → \"SAML Metadata\" to copy the metadata URL."
         },
         {
           "type": "image",
           "src": "/wizards/onelogin/saml/onelogin_saml_6a.png"
+        },
+        {
+          "type": "text",
+          "content": "Paste the metadata URL below to import the OneLogin IdP configuration into Keycloak."
         },
         {
           "type": "formGroup",
@@ -87,15 +109,27 @@
       ]
     },
     {
-      "id": 3,
+      "id": 4,
       "title": "Configure Attribute Mapping",
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "Open the \"Parameters\" tab and click the \"+\" icon to add each of the following SAML attribute parameters."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/onelogin/saml/onelogin_saml_5.png"
+        },
+        {
+          "type": "text",
+          "content": "For each parameter, enable \"Include in SAML assertion\" and map it to the corresponding user attribute."
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "LDAP Attribute",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "uid",
@@ -117,21 +151,17 @@
         },
         {
           "type": "image",
-          "src": "/wizards/onelogin/saml/onelogin_saml_5.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/onelogin/saml/onelogin_saml_5a.png"
         }
       ]
     },
     {
-      "id": 4,
-      "title": "Configure User Access",
+      "id": 5,
+      "title": "Assign User Access",
       "blocks": [
         {
           "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+          "content": "Switch to the \"Access\" tab and choose the Roles that should have access to this application, then click \"Save\"."
         },
         {
           "type": "image",
@@ -140,7 +170,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "title": "Confirmation",
       "type": "confirm",
       "blocks": [

--- a/apps/wizard-v2/wizards/oracle/saml.json
+++ b/apps/wizard-v2/wizards/oracle/saml.json
@@ -21,15 +21,96 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Add a SAML Application in Oracle IdCS",
       "blocks": [
         {
           "type": "text",
-          "content": "In Oracle Identity Cloud Service, create a new SAML application. Enter the following service provider details."
+          "content": "Sign in to your Oracle Identity Cloud Service admin console."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/oracle/SAML/oracle_saml_0.png"
+        },
+        {
+          "type": "text",
+          "content": "In the navigation menu, select \"Applications\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/oracle/SAML/oracle_saml_1.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Add\" to open the application catalog."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/oracle/SAML/oracle_saml_2.png"
+        },
+        {
+          "type": "text",
+          "content": "Select \"SAML Application\" as the application type."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/oracle/SAML/oracle_saml_3.png"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Download Identity Provider Metadata",
+      "enableNextWhen": "state.metadataValidated",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Enter a name and description for the application on the Details tab, then save and activate it."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/oracle/SAML/oracle_saml_4.png"
+        },
+        {
+          "type": "text",
+          "content": "From the application page, click \"Download Identity Provider Metadata\" to save the IdP metadata XML file."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/oracle/SAML/oracle_saml_5.png"
+        },
+        {
+          "type": "text",
+          "content": "Upload the downloaded XML file below to import the Oracle IdP configuration into Keycloak."
+        },
+        {
+          "type": "formGroup",
+          "id": "metadataInput",
+          "exclusive": false,
+          "forms": [
+            "metadataFile"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Configure Service Provider Settings",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Back in the Oracle IdCS application, open the \"SSO Configuration\" tab and expand the \"Service Provider Configuration\" section."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/oracle/SAML/oracle_saml_6.png"
+        },
+        {
+          "type": "text",
+          "content": "Enter the following values into the Service Provider fields."
         },
         {
           "type": "copy",
-          "label": "ACS URL",
+          "label": "ACS URL (Assertion Consumer URL)",
           "value": "{{api.ssoUrl}}",
           "hint": "Sometimes called SSO Service URL or Callback URL"
         },
@@ -47,67 +128,32 @@
         },
         {
           "type": "image",
-          "src": "/wizards/oracle/SAML/oracle_saml_0.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/oracle/SAML/oracle_saml_1.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/oracle/SAML/oracle_saml_2.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/oracle/SAML/oracle_saml_3.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/oracle/SAML/oracle_saml_4.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/oracle/SAML/oracle_saml_6.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/oracle/SAML/oracle_saml_7.png"
         }
       ]
     },
     {
-      "id": 2,
-      "title": "Upload Identity Provider Metadata",
-      "enableNextWhen": "state.metadataValidated",
-      "blocks": [
-        {
-          "type": "text",
-          "content": "Download the Oracle IdP metadata XML file and upload it here."
-        },
-        {
-          "type": "image",
-          "src": "/wizards/oracle/SAML/oracle_saml_5.png"
-        },
-        {
-          "type": "formGroup",
-          "id": "metadataInput",
-          "exclusive": false,
-          "forms": [
-            "metadataFile"
-          ]
-        }
-      ]
-    },
-    {
-      "id": 3,
+      "id": 4,
       "title": "Configure Attribute Mapping",
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "Still on the SSO Configuration page, expand the \"Attribute Configuration\" section."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/oracle/SAML/oracle_saml_8.png"
+        },
+        {
+          "type": "text",
+          "content": "Add the following attribute mappings so Oracle IdCS sends user attributes in the SAML assertion. Click \"Save\" when done."
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "LDAP Attribute",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "uid",
@@ -129,25 +175,25 @@
         },
         {
           "type": "image",
-          "src": "/wizards/oracle/SAML/oracle_saml_8.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/oracle/SAML/oracle_saml_9.png"
         }
       ]
     },
     {
-      "id": 4,
-      "title": "Configure User Access",
+      "id": 5,
+      "title": "Assign User Access",
       "blocks": [
         {
           "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+          "content": "Open the \"Application Roles\" tab and grant access to the users or groups who should be able to sign in."
         },
         {
           "type": "image",
           "src": "/wizards/oracle/SAML/oracle_saml_10.png"
+        },
+        {
+          "type": "text",
+          "content": "Confirm the assignments, then return here to finish."
         },
         {
           "type": "image",
@@ -156,7 +202,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "title": "Confirmation",
       "type": "confirm",
       "blocks": [

--- a/apps/wizard-v2/wizards/pingone/saml.json
+++ b/apps/wizard-v2/wizards/pingone/saml.json
@@ -92,6 +92,10 @@
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "LDAP Attribute",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "uid",

--- a/apps/wizard-v2/wizards/salesforce/saml.json
+++ b/apps/wizard-v2/wizards/salesforce/saml.json
@@ -21,11 +21,49 @@
   "steps": [
     {
       "id": 1,
-      "title": "Create a SAML Application",
+      "title": "Enable Identity Provider and Create a Connected App",
       "blocks": [
         {
           "type": "text",
-          "content": "In Salesforce, enable the Identity Provider under Setup → Identity → Identity Provider. Then create a Connected App with SAML enabled."
+          "content": "In Salesforce Setup, navigate to Identity → Identity Provider and click \"Enable Identity Provider\". Accept the default certificate."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/salesforce/SAML/salesforce_saml_0.png"
+        },
+        {
+          "type": "text",
+          "content": "Go to Setup → Apps → App Manager and click \"New Connected App\"."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/salesforce/COMMON/salesforce-0.png"
+        },
+        {
+          "type": "text",
+          "content": "Enter a Connected App Name, API Name, and Contact Email in the Basic Information section."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/salesforce/COMMON/salesforce-1.png"
+        },
+        {
+          "type": "text",
+          "content": "Scroll to the Web App Settings section to begin configuring SAML."
+        },
+        {
+          "type": "image",
+          "src": "/wizards/salesforce/COMMON/salesforce-2.png"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Configure SAML Settings",
+      "blocks": [
+        {
+          "type": "text",
+          "content": "Check \"Enable SAML\" in the Web App Settings section and enter the following service provider values."
         },
         {
           "type": "copy",
@@ -47,34 +85,22 @@
         },
         {
           "type": "image",
-          "src": "/wizards/salesforce/SAML/salesforce_saml_0.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/salesforce/COMMON/salesforce-0.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/salesforce/COMMON/salesforce-1.png"
-        },
-        {
-          "type": "image",
-          "src": "/wizards/salesforce/COMMON/salesforce-2.png"
-        },
-        {
-          "type": "image",
           "src": "/wizards/salesforce/SAML/salesforce_saml_1.png"
+        },
+        {
+          "type": "text",
+          "content": "Click \"Save\" to create the Connected App. Salesforce may take a few minutes to provision it."
         }
       ]
     },
     {
-      "id": 2,
-      "title": "Configure Application Metadata",
+      "id": 3,
+      "title": "Import Salesforce IdP Metadata",
       "enableNextWhen": "state.metadataValidated",
       "blocks": [
         {
           "type": "text",
-          "content": "Enter the metadata URL from your Salesforce Identity Provider settings."
+          "content": "Return to Setup → Identity → Identity Provider and click \"Download Metadata\". Alternatively, copy the metadata URL directly."
         },
         {
           "type": "image",
@@ -83,6 +109,10 @@
         {
           "type": "image",
           "src": "/wizards/salesforce/SAML/salesforce_saml_2.png"
+        },
+        {
+          "type": "text",
+          "content": "Paste the metadata URL below to import the Salesforce IdP configuration into Keycloak."
         },
         {
           "type": "formGroup",
@@ -95,15 +125,19 @@
       ]
     },
     {
-      "id": 3,
+      "id": 4,
       "title": "Configure Attribute Mapping",
       "blocks": [
         {
           "type": "text",
-          "content": "Configure your identity provider to send the following SAML attributes."
+          "content": "Back in the Connected App, scroll to the Custom Attributes section and click \"New\" to add the following SAML attributes."
         },
         {
           "type": "attributeTable",
+          "columns": {
+            "idpAttribute": "SAML Attribute Name",
+            "keycloakAttribute": "Keycloak User Field"
+          },
           "rows": [
             {
               "idpAttribute": "username",
@@ -128,22 +162,30 @@
           "src": "/wizards/salesforce/SAML/salesforce_saml_3.png"
         },
         {
+          "type": "text",
+          "content": "Map each attribute to the corresponding User field (User.Username, User.Email, etc.) and click \"Save\"."
+        },
+        {
           "type": "image",
           "src": "/wizards/salesforce/SAML/salesforce_saml_4.png"
         }
       ]
     },
     {
-      "id": 4,
-      "title": "Configure User Access",
+      "id": 5,
+      "title": "Assign Profiles and Permission Sets",
       "blocks": [
         {
           "type": "text",
-          "content": "Assign the users or groups who should have access in your identity provider, then continue."
+          "content": "Click \"Manage Profiles\" or \"Manage Permission Sets\" on the Connected App and assign the users who should have access."
         },
         {
           "type": "image",
           "src": "/wizards/salesforce/COMMON/salesforce-4.png"
+        },
+        {
+          "type": "text",
+          "content": "Verify the assigned users, then return here to finish."
         },
         {
           "type": "image",
@@ -152,7 +194,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "title": "Confirmation",
       "type": "confirm",
       "blocks": [


### PR DESCRIPTION
## Summary
- 10 new SAML wizards: PingFederate, VMware, Keycloak, Rippling, ClassLink, miniOrange, NetIQ, CAS, Shibboleth, SimpleSAMLphp
- 6 new OIDC wizards: Okta, Entra ID, Google, Clever, ADP, Login.gov
- Updated provider registry with all new entries
- Covers 16 of 48 items from #262 (16 more already existed)

## Details
All wizards are JSON-only — no new React components. They follow existing patterns:
- SAML: URL metadata or file upload variants
- OIDC: domain-based, tenant-based, or fixed discovery URL variants
- Login.gov uses `private_key_jwt` auth method

## Test plan
- [ ] `pnpm build` passes
- [ ] Dev server shows new providers in selector
- [ ] Click through wizard steps for at least one new SAML and one new OIDC provider
- [ ] Existing E2E tests still pass

Refs #262