### PR TITLE
Update namespace URIs in Entra ID SAML configuration

### DIFF
--- a/apps/wizard-v2/src/components/wizard/WizardStep.tsx
+++ b/apps/wizard-v2/src/components/wizard/WizardStep.tsx
@@ -466,7 +466,7 @@ const DEFAULT_COLUMNS: Record<string, string> = {
 
 const ATTRIBUTE_COLUMN_CLASSES: Record<string, string> = {
   name: "w-44 min-w-44",
-  namespace: "min-w-[38rem]",
+  namespace: "min-w-[30rem]",
   value: "w-72 min-w-72",
   idpAttribute: "min-w-[28rem]",
   keycloakAttribute: "min-w-[18rem]",

--- a/apps/wizard-v2/wizards/entraid/saml.json
+++ b/apps/wizard-v2/wizards/entraid/saml.json
@@ -164,22 +164,22 @@
           "rows": [
             {
               "name": "emailaddress",
-              "namespace": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+              "namespace": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims",
               "value": "user.mail"
             },
             {
               "name": "givenname",
-              "namespace": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+              "namespace": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims",
               "value": "user.givenname"
             },
             {
               "name": "name",
-              "namespace": "http://schemas.microsoft.com/identity/claims/name",
+              "namespace": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims",
               "value": "user.userprincipalname"
             },
             {
               "name": "surname",
-              "namespace": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+              "namespace": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims",
               "value": "user.surname"
             }
           ]
@@ -308,23 +308,23 @@
       "contentType": "json",
       "foreach": [
         {
-          "attributeName": "username",
-          "friendlyName": "username",
+          "attributeName": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+          "friendlyName": "",
           "userAttribute": "username"
         },
         {
-          "attributeName": "email",
-          "friendlyName": "email",
+          "attributeName": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+          "friendlyName": "",
           "userAttribute": "email"
         },
         {
-          "attributeName": "firstName",
-          "friendlyName": "firstName",
+          "attributeName": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+          "friendlyName": "",
           "userAttribute": "firstName"
         },
         {
-          "attributeName": "lastName",
-          "friendlyName": "lastName",
+          "attributeName": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+          "friendlyName": "",
           "userAttribute": "lastName"
         }
       ],


### PR DESCRIPTION
## Summary

Corrects the Entra ID SAML wizard so the claim namespaces and Keycloak attribute mappers match what Entra ID actually emits in its SAML assertions.

## Changes

**`apps/wizard-v2/wizards/entraid/saml.json`**

- Claims table (`rows`): the `namespace` values now hold only the base namespace (`http://schemas.xmlsoap.org/ws/2005/05/identity/claims`) instead of the fully-qualified claim URI. In Entra ID the namespace and the claim name are configured as separate fields, so appending the name to the namespace produced invalid claim URIs.
- The `name` claim was additionally moved off `http://schemas.microsoft.com/identity/claims` onto the same xmlsoap namespace as the other claims for consistency.
- Attribute importer mappers (`foreach`): `attributeName` now uses the fully-qualified claim URI that appears in the assertion (e.g. `.../claims/givenname`) rather than the short logical name (`firstName`), so the mappers actually match incoming attributes. `friendlyName` is cleared, since Entra ID does not send a FriendlyName and a mismatched value prevents the mapper from matching.

**`apps/wizard-v2/src/components/wizard/WizardStep.tsx`**

- Reduced the `namespace` attribute column from `min-w-[38rem]` to `min-w-[30rem]`, since the shortened namespace values no longer need the extra width.