### PR TITLE
Strip OIDC response params before using the URL as redirect_uri

### DIFF
--- a/src/app/hooks/useCreateTestIdpLink.ts
+++ b/src/app/hooks/useCreateTestIdpLink.ts
@@ -2,6 +2,7 @@ import { useApi } from "./useApi";
 import { Axios } from "@app/components/IdentityProviderWizard/Wizards/services";
 import { Protocols } from "@app/configurations";
 import { useKeycloakAdminApi } from "./useKeycloakAdminApi";
+import { stripOidcParams } from "@app/utils/oidc-params";
 
 export function useCreateTestIdpLink() {
   const { baseServerRealmsUrl, endpoints } = useApi();
@@ -22,7 +23,10 @@ export function useCreateTestIdpLink() {
   };
 
   const generateValidationUrl = (alias: string) => {
-    return `${baseServerRealmsUrl}/${realm}/protocol/openid-connect/auth?client_id=idp-tester&redirect_uri=${window.location.href}&response_type=code&scope=openid&kc_idp_hint=${alias}&prompt=login`;
+    const redirectUri = encodeURIComponent(
+      stripOidcParams(window.location.href),
+    );
+    return `${baseServerRealmsUrl}/${realm}/protocol/openid-connect/auth?client_id=idp-tester&redirect_uri=${redirectUri}&response_type=code&scope=openid&kc_idp_hint=${alias}&prompt=login`;
   };
 
   const isValidationPendingForAlias = async (alias: string) => {

--- a/src/app/utils/oidc-params.test.ts
+++ b/src/app/utils/oidc-params.test.ts
@@ -1,0 +1,52 @@
+import { stripOidcParams } from "./oidc-params";
+
+const WIZARD = "https://auth.example.com/realms/demo/wizard";
+
+describe("stripOidcParams", () => {
+  it("strips an authorization response delivered in the query string", () => {
+    expect(
+      stripOidcParams(
+        `${WIZARD}?session_state=OM9AhsGCQhFuwqfV&iss=${encodeURIComponent(
+          "https://auth.example.com/realms/demo"
+        )}&code=1f0c4e2a-0000-4a1b-9c3d-2b7e5a1d4c88`
+      )
+    ).toBe(WIZARD);
+  });
+
+  it("strips an authorization response delivered in the fragment", () => {
+    expect(
+      stripOidcParams(
+        `${WIZARD}/#state=7c1de904&session_state=OM9AhsGC&iss=x&code=b3a17f52`
+      )
+    ).toBe(`${WIZARD}/`);
+  });
+
+  it("strips an error response", () => {
+    expect(
+      stripOidcParams(`${WIZARD}?error=access_denied&error_description=nope`)
+    ).toBe(WIZARD);
+  });
+
+  it("matches parameter names case-insensitively, as Keycloak does", () => {
+    expect(stripOidcParams(`${WIZARD}?CODE=abc&Session_State=xyz`)).toBe(
+      WIZARD
+    );
+  });
+
+  it("keeps parameters Keycloak does not forbid", () => {
+    expect(stripOidcParams(`${WIZARD}?org_id=abc&code=xyz`)).toBe(
+      `${WIZARD}?org_id=abc`
+    );
+  });
+
+  it("leaves a hash route alone", () => {
+    expect(stripOidcParams(`${WIZARD}/#/idp/okta`)).toBe(
+      `${WIZARD}/#/idp/okta`
+    );
+  });
+
+  it("leaves a clean URL byte-identical", () => {
+    const clean = `${WIZARD}/?a=b%3Ac#/idp/okta`;
+    expect(stripOidcParams(clean)).toBe(clean);
+  });
+});

--- a/src/app/utils/oidc-params.ts
+++ b/src/app/utils/oidc-params.ts
@@ -1,0 +1,81 @@
+/**
+ * OIDC response parameters that Keycloak refuses to accept nested inside a
+ * `redirect_uri`. Mirrors `FORBIDDEN_OIDC_PARAMS` in Keycloak's
+ * `RedirectUtils`, added in 26.6.5 as HTTP-parameter-pollution hardening.
+ *
+ * The check runs before redirect URI matching, so a `redirect_uri` carrying any
+ * of these is rejected with "Invalid parameter: redirect_uri" no matter how the
+ * client is registered.
+ */
+export const FORBIDDEN_OIDC_PARAMS = [
+  "code",
+  "id_token",
+  "access_token",
+  "token_type",
+  "expires_in",
+  "state",
+  "iss",
+  "error",
+  "error_description",
+  "session_state",
+  "response",
+  "kc_action",
+  "kc_action_status",
+];
+
+const isForbidden = (name: string) =>
+  FORBIDDEN_OIDC_PARAMS.includes(name.toLowerCase());
+
+const hasForbidden = (params: string) =>
+  Array.from(new URLSearchParams(params).keys()).some(isForbidden);
+
+const withoutForbidden = (params: string) => {
+  const search = new URLSearchParams(params);
+  Array.from(search.keys())
+    .filter(isForbidden)
+    .forEach((name) => search.delete(name));
+  return search.toString();
+};
+
+/**
+ * Remove OIDC response parameters from a URL so it is safe to hand to Keycloak
+ * as a `redirect_uri`. Untouched — byte for byte — when there is nothing to
+ * strip, so hash routes and ordinary query parameters survive intact.
+ */
+export const stripOidcParams = (href: string): string => {
+  const url = new URL(href);
+
+  if (hasForbidden(url.search)) {
+    const stripped = withoutForbidden(url.search);
+    url.search = stripped ? `?${stripped}` : "";
+  }
+
+  // response_mode=fragment delivers the same parameters in the fragment.
+  const fragment = url.hash.replace(/^#/, "");
+  if (fragment.includes("=") && hasForbidden(fragment)) {
+    const stripped = withoutForbidden(fragment);
+    url.hash = stripped ? `#${stripped}` : "";
+  }
+
+  return url.toString();
+};
+
+/**
+ * Drop OIDC response parameters from the address bar without reloading, and
+ * return the cleaned URL.
+ *
+ * The portal link (`POST /orgs/{id}/portal-link`) lands the user on the wizard
+ * with an authorization response in the *query* string, while keycloak-js reads
+ * the *fragment* by default. keycloak-js therefore never consumes those
+ * parameters, and its subsequent `login()` defaults `redirect_uri` to
+ * `window.location.href` — which still carries them, and is rejected.
+ */
+export const stripOidcParamsFromLocation = (): string => {
+  const cleaned = stripOidcParams(window.location.href);
+
+  if (cleaned !== window.location.href) {
+    window.history.replaceState({}, "", cleaned);
+  }
+
+  return cleaned;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import { PersistGate } from "redux-persist/integration/react";
 import { persistStore } from "redux-persist";
 let persistor = persistStore(store);
 import { Toaster } from "react-hot-toast";
+import { stripOidcParamsFromLocation } from "@app/utils/oidc-params";
 
 if (process.env.NODE_ENV !== "production") {
   const config = {
@@ -25,11 +26,17 @@ if (process.env.NODE_ENV !== "production") {
   axe(React, ReactDOM, 1000, config);
 }
 
+// Must run before keycloak-js initializes: it defaults `redirect_uri` to
+// window.location.href, and Keycloak rejects that URL outright if it still
+// carries an OIDC response (as it does when arriving via a portal link).
+const redirectUri = stripOidcParamsFromLocation();
+
 ReactDOM.render(
   <ReactKeycloakProvider
     authClient={keycloak}
     initOptions={{
       onLoad: "login-required",
+      redirectUri,
       silentCheckSsoRedirectUri:
         window.location.origin + "/silent-check-sso.html",
     }}


### PR DESCRIPTION
## Problem

Opening the wizard through an organization **portal link** fails with `400 Invalid parameter: redirect_uri`, on any realm running Keycloak **26.6.5 or newer**. Reproduced on two unrelated realms on separate clusters.

The `redirect_uri` itself looks fine, which is what makes this confusing — the problem is what is *nested inside* it.

## Root cause

`POST /orgs/{id}/portal-link` mints an action token whose `client_data` is `{"ru":"https://{host}/realms/{realm}/wizard","rt":"code"}` — no response mode, so Keycloak delivers the authorization response in the **query string**:

```
GET  /realms/{realm}/login-actions/action-token?key=…      302
GET  /realms/{realm}/login-actions/required-action?…       302
  ==> /realms/{realm}/wizard?session_state=…&iss=…&code=…       ← query, not fragment
GET  /realms/{realm}/wizard?code=…                         200  ← wizard boots
GET  /protocol/openid-connect/auth?…                       400
     redirect_uri = https://{host}/realms/{realm}/wizard?session_state=…&iss=…&code=…
     response_mode = fragment
```

keycloak-js defaults to `responseMode: "fragment"`, so it looks only at the fragment. It never sees that code — there is no `state` in the response either, so it could not consume it even in query mode — never cleans the URL, and `onLoad: "login-required"` starts a fresh login. keycloak-js defaults `redirect_uri` to `window.location.href`, which still carries `session_state`, `iss` and `code`.

Keycloak 26.6.5 (`1f58a4b79a`, "Reject redirect URIs containing pre-loaded OIDC response parameters", backport of keycloak#49959) added `FORBIDDEN_OIDC_PARAMS` to `RedirectUtils`. `containsForbiddenOidcParameters()` runs *before* redirect URI matching, so the request is rejected no matter how the client is registered, and there is no configuration knob to relax it.

The client registration is not at fault, and neither is the trailing slash — `matchesRedirects` strips the query and the wildcard's trailing `/`, so `…/wizard` matches `…/wizard/*` fine. The control case: clicking "Back to Application" hits the identical endpoint on the identical realm with a clean `redirect_uri=…/wizard/`, gets a 302 with the code in the fragment, and completes the token exchange. This flow worked on 26.6.4 and earlier.

## Fix

Strip OIDC response parameters from the address bar before keycloak-js initializes, and pass the cleaned URL as `redirect_uri` explicitly. The portal link's action token has already established the session, so login SSOs straight through — no second prompt.

`stripOidcParams` returns its input **byte for byte** when there is nothing to strip, so this is a no-op for every other entry point into the wizard: hash routes, ordinary query parameters and their existing encoding all survive untouched.

Also fixes a latent instance of the same defect at `src/app/hooks/useCreateTestIdpLink.ts:25`, which interpolated `window.location.href` into the IdP validation URL raw — both unsanitized *and* unencoded.

The forbidden-parameter list mirrors Keycloak's, with a comment pointing at the source, so the coupling is discoverable when Keycloak changes it.

## Verification

- 7 unit tests over `stripOidcParams` covering query and fragment delivery, error responses, case-insensitive matching as Keycloak does it, and the byte-identical no-op cases — all pass.
- `tsc --noEmit` reports no new errors; the pre-existing ones are untouched. This also confirms `redirectUri` is a valid `KeycloakInitOptions` field.
- New files are Prettier-clean.

Two pre-existing problems I deliberately did **not** touch:

- `jest.config.js`'s `snapshotSerializers: ['enzyme-to-json/serializer']` fails to load at HEAD (`cheerio` ships ESM), which breaks the whole suite before any test runs. The new tests were therefore verified with a config override:
  ```
  npx jest -c '{"preset":"ts-jest/presets/js-with-ts","testEnvironment":"jsdom","rootDir":".","moduleNameMapper":{"@app/(.*)":"<rootDir>/src/$1"}}' src/app/utils/oidc-params.test.ts
  ```
  CI runs Maven and Cypress, not jest, so nothing regresses — but `npm test` is broken on `main` and worth a separate fix.
- `src/index.tsx` and `src/app/hooks/useCreateTestIdpLink.ts` were already failing `prettier --check` before this change, so I left their formatting alone rather than inflating the diff.

Also worth noting separately: `main` has no ESLint config, so the `eslint` package script cannot run.

## Follow-up (not in this PR)

Optional, server side: the portal link requests `rt=code` against a client that throws the code away. Not required now, but removing it would stop generating the dirty URL at the source.
