### PR TITLE
Fix the portal-link login loop, protocol page centering, and the local docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN set -e; \
     echo "No existing idp-wizard jar found in base image." >&2; \
     exit 1; \
   fi; \
-  cp /tmp/phasetwo-idp-wizard.jar "$target"; \
-  rm -f /tmp/phasetwo-idp-wizard.jar
+  cp /tmp/phasetwo-idp-wizard.jar "$target"
 
 RUN /opt/keycloak/bin/kc.sh build
 

--- a/src/app/components/IdentityProviderWizard/IdentityProviderSelector/IdPProtocolSelector.tsx
+++ b/src/app/components/IdentityProviderWizard/IdentityProviderSelector/IdPProtocolSelector.tsx
@@ -49,7 +49,7 @@ export const IdPProtocolSelector: FC = ({}) => {
 
   return (
     <Stack id="protocol-selector" className="container">
-      <StackItem isFilled className="justify-items-center">
+      <StackItem isFilled className="center-stack-items">
         <StackItem>
           <Link to={generatePath(PATHS.idpSelector, { realm })}>
             <Button

--- a/src/app/styles/app.css
+++ b/src/app/styles/app.css
@@ -219,6 +219,13 @@ body,
   vertical-align: middle;
 }
 
-.justify-items-center {
-  justify-items: center;
+/* Centers the stacked children of a pf-l-stack__item. The item is a flex
+ * *item* of the stack, not a container, so it has to become a flex column
+ * before its children can be aligned — `justify-items` alone is inert here,
+ * being a grid-only property. */
+.center-stack-items {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }

--- a/src/app/utils/oidc-params.test.ts
+++ b/src/app/utils/oidc-params.test.ts
@@ -1,4 +1,4 @@
-import { stripOidcParams } from "./oidc-params";
+import { stripOidcParams, stripOidcParamsFromLocation } from "./oidc-params";
 
 const WIZARD = "https://auth.example.com/realms/demo/wizard";
 
@@ -48,5 +48,41 @@ describe("stripOidcParams", () => {
   it("leaves a clean URL byte-identical", () => {
     const clean = `${WIZARD}/?a=b%3Ac#/idp/okta`;
     expect(stripOidcParams(clean)).toBe(clean);
+  });
+});
+
+describe("stripOidcParamsFromLocation", () => {
+  const setUrl = (url: string) => window.history.replaceState({}, "", url);
+  const APP = "/auth/realms/test/wizard";
+
+  it("clears an authorization response delivered in the query string", () => {
+    setUrl(`${APP}?session_state=abc&iss=http%3A%2F%2Fx&code=def`);
+
+    const redirectUri = stripOidcParamsFromLocation();
+
+    expect(window.location.search).toBe("");
+    expect(redirectUri).toBe(`http://localhost${APP}`);
+  });
+
+  it("preserves a fragment callback so keycloak-js can consume it", () => {
+    // response_mode=fragment: clearing this strands the login round-trip in a
+    // redirect loop that never reaches the token endpoint.
+    const fragment =
+      "#state=cb262493&session_state=39f&iss=http%3A%2F%2Fx&code=0960ad66";
+    setUrl(`${APP}${fragment}`);
+
+    const redirectUri = stripOidcParamsFromLocation();
+
+    expect(window.location.hash).toBe(fragment);
+    expect(redirectUri).toBe(`http://localhost${APP}`);
+  });
+
+  it("leaves a clean URL untouched", () => {
+    setUrl(`${APP}?org_id=abc`);
+
+    expect(stripOidcParamsFromLocation()).toBe(
+      `http://localhost${APP}?org_id=abc`
+    );
+    expect(window.location.search).toBe("?org_id=abc");
   });
 });

--- a/src/app/utils/oidc-params.ts
+++ b/src/app/utils/oidc-params.ts
@@ -62,20 +62,29 @@ export const stripOidcParams = (href: string): string => {
 
 /**
  * Drop OIDC response parameters from the address bar without reloading, and
- * return the cleaned URL.
+ * return a URL that is safe to hand to Keycloak as `redirect_uri`.
  *
  * The portal link (`POST /orgs/{id}/portal-link`) lands the user on the wizard
  * with an authorization response in the *query* string, while keycloak-js reads
  * the *fragment* by default. keycloak-js therefore never consumes those
  * parameters, and its subsequent `login()` defaults `redirect_uri` to
  * `window.location.href` — which still carries them, and is rejected.
+ *
+ * Only the query string is cleared. Under `response_mode=fragment` the fragment
+ * is keycloak-js's own callback channel, so clearing it here would delete the
+ * authorization response before keycloak-js could read it — leaving the app in
+ * a login redirect loop that never reaches the token endpoint. The returned
+ * redirect target is stripped of both, because Keycloak rejects these
+ * parameters wherever they appear in a `redirect_uri`.
  */
 export const stripOidcParamsFromLocation = (): string => {
-  const cleaned = stripOidcParams(window.location.href);
+  const url = new URL(window.location.href);
 
-  if (cleaned !== window.location.href) {
-    window.history.replaceState({}, "", cleaned);
+  if (hasForbidden(url.search)) {
+    const stripped = withoutForbidden(url.search);
+    url.search = stripped ? `?${stripped}` : "";
+    window.history.replaceState({}, "", url.toString());
   }
 
-  return cleaned;
+  return stripOidcParams(window.location.href);
 };


### PR DESCRIPTION
Three fixes that need to ship together, because none of them can be verified without the others: the loop makes the wizard unreachable, and the Dockerfile bug makes the local build impossible.

**v0.51 carries the loop regression** — see "Before deploying" at the bottom.

---

## 1. Keep the fragment callback intact when clearing OIDC params

#278 fixed the `400 Invalid parameter: redirect_uri` on the portal-link flow, but introduced an infinite login loop.

`stripOidcParamsFromLocation` cleared the forbidden OIDC parameters from *both* the query string and the fragment before keycloak-js initialized. Under `response_mode=fragment` — the keycloak-js default, and what the wizard uses — the fragment is keycloak-js's own callback channel. Clearing it deleted the authorization response before keycloak-js could read it.

keycloak-js then saw an unauthenticated user, `onLoad: "login-required"` started another login, and the round trip repeated forever:

```
GET  /protocol/openid-connect/auth?…&response_mode=fragment   302
  ==> /realms/{realm}/wizard#state=…&session_state=…&code=…
     (parameters stripped; callback never parsed)
GET  /protocol/openid-connect/auth?…                          302
  ==> …
```

A HAR of the loop showed 23 iterations and **zero** requests to `/protocol/openid-connect/token` — the code was never redeemed, which is the signature of the callback being destroyed rather than rejected.

**Fix:** clear only the **query string**. That is where the portal link delivers its response, and keycloak-js does not read it in fragment mode, so nothing is lost. The fragment is left byte-identical. The value returned for `redirect_uri` is still stripped of both components, because Keycloak rejects these parameters wherever they appear in a redirect URI. The two outputs differ deliberately, and the comment on the function explains why. The wizard uses `BrowserRouter`, so the fragment is never a route here.

## 2. Restore centering on the connection protocol page

The back link, provider logo, heading and description have rendered left-aligned since `4e25d84` (first released in **v0.37** — unrelated to #278, and live in the currently deployed 0.49). That commit moved the provider logo out of `.selection-container` — a real grid with `justify-content: center` — and replaced the centering with a new `.justify-items-center` class on the wrapping `StackItem`.

`justify-items` is a grid-only property and `pf-l-stack` is a flex column, so the replacement was inert: the centering was removed and nothing took its place. Only the SAML/OIDC button row stayed centered, because it kept its own `.selection-container`.

Setting `align-items` instead is not enough either — the class sits on a `pf-l-stack__item`, which is a flex *item* of the stack rather than a container, so its children are ordinary blocks. It has to become a flex column itself. Renamed to `.center-stack-items`, since the rule no longer has anything to do with `justify-items`; it has exactly one usage.

## 3. Drop the unreachable /tmp cleanup from the builder stage

`docker compose up --build`, the local build documented in the README, fails on the builder stage:

```
rm: can't remove '/tmp/phasetwo-idp-wizard.jar': Operation not permitted
```

The base image runs as `USER keycloak` (uid 2000) and `/tmp` is `drwxrwxrwt`, so the sticky bit only lets the file's owner unlink it. `COPY` lands the jar there owned by root, so the `rm` can never succeed — while `cp` works, because `/opt/keycloak/providers` is keycloak-owned. The cleanup was pointless regardless: it runs in the builder stage, and the final stage copies only `lib/quarkus/` and `providers/`, so the `/tmp` jar never reaches the published image.

---

## Verification

End to end against a local Keycloak **26.6.6** with the wizard JAR built from this branch, driving the **real portal-link flow** (`POST /orgs/{id}/portal-link` → action token → wizard):

```
1  login-actions/action-token          302
2  login-actions/required-action       302  ==> /wizard?session_state=…&iss=…&code=…
11 openid-connect/auth                 302  ← one only, redirect_uri clean
12 /wizard                             200
20 POST openid-connect/token           200  ← code redeemed
```

One authorization request, one token exchange, no loop, wizard renders. Both the original 400 and the loop are fixed on the same setup.

Centering confirmed visually on the Auth0 protocol page (two protocols, so the single-protocol auto-redirect does not fire): all four stacked items and the button row centered.

Unit tests: 10 total, including a regression test asserting the fragment survives `stripOidcParamsFromLocation`. Confirmed it **fails against the previous implementation** — exactly that one case — and passes against this one, so the gap that let the loop through is now covered.

The jest suite is still broken at HEAD independently of this change (`enzyme-to-json` → `cheerio` ESM), so tests were run with an override:

```
npx jest -c '{"preset":"ts-jest/presets/js-with-ts","testEnvironment":"jsdom","rootDir":".","moduleNameMapper":{"@app/(.*)":"<rootDir>/src/$1"}}' src/app/utils/oidc-params.test.ts
```

## Before deploying

**Do not pin 0.51 anywhere.** It contains the loop, which is a worse failure than the 400 it replaced — the 400 at least left the user on an error page, whereas the loop hammers the authorization endpoint. A release cut from this branch is needed first, and that is the version to pin in `phasetwo-containers` (`libs/pom.xml`, currently `0.49`).
